### PR TITLE
初始值与结构体定义不符

### DIFF
--- a/src/compress/rpc_compress_lz4.h
+++ b/src/compress/rpc_compress_lz4.h
@@ -38,7 +38,7 @@ static constexpr LZ4F_preferences_t kPrefs = {
 	},
 	0,   /* compression level; 0 == default */
 	0,   /* autoflush */
-	0,   /* favor decompression speed */
+	// 0,   /* favor decompression speed */
 	{ 0, 0, 0 },  /* reserved, must be set to 0 */
 };
 


### PR DESCRIPTION
LZ4F_preferences_t结构体