### PR TITLE
fix(parser): 修复parser解析多行注释错误

### DIFF
--- a/src/generator/parser.cc
+++ b/src/generator/parser.cc
@@ -72,9 +72,12 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 
 		if ((state & PARSER_ST_COMMENT_MASK) == PARSER_ST_INSIDE_COMMENT)
 		{
-			if (this->check_multi_comments_end(line))
+			if (this->check_multi_comments_end(line)) 
+			{
 				state -= PARSER_ST_INSIDE_COMMENT;
-			//	state |= PARSER_ST_OUTSIDE_COMMENT_MASK;
+				//	state |= PARSER_ST_OUTSIDE_COMMENT_MASK;
+				if (line.empty()) continue;
+			}
 			else
 				continue;
 


### PR DESCRIPTION
当遇到多行注释结尾标志"*/"后没有多余字符的时候，check_block_begin 会多读入一行，导致读入后的这行代码可能没有被正确解析。

Bug 复现：解析如下bug.thrift IDL文件，其中inclue "other.thrift" 这行不能被正确解析，导致无法include 其他文件

```
/** comment
 * line1
 */
include "other.thrift"
```

但是如下内容的文件则能被原来的代码正确解析。

```
/** comment
 * line1
 */

include "other.thrift"
```