### PR TITLE
fix:  thrift exception errmsg wrong  && thrift parse map type field fail

### DIFF
--- a/src/generator/parser.cc
+++ b/src/generator/parser.cc
@@ -365,9 +365,6 @@ static std::string gen_param_var(const std::string& type_name, size_t& cur)
 
 	auto idl_type = SGenUtil::strip(type_name.substr(st, cur - st));
 
-	if (type_name[cur] == ',' || type_name[cur] == '>')
-		cur++;
-
 	if (idl_type == "bool")
 		return "bool";
 	else if (idl_type == "i8" || idl_type == "byte")

--- a/src/message/rpc_message_thrift.cc
+++ b/src/message/rpc_message_thrift.cc
@@ -126,38 +126,9 @@ bool ThriftResponse::serialize_meta()
 	return TBuffer_.writeMessageBegin();
 }
 
-bool ThriftResponse::deserialize_meta()
+const char * thrift_error2errmsg(int error) 
 {
-	if (TBuffer_.readMessageBegin())
-	{
-		if (TBuffer_.meta.message_type == TMT_EXCEPTION)
-		{
-			ThriftException ex;
-
-			if (ex.descriptor->reader(&TBuffer_, &ex))
-			{
-				status_code_ = (ex.type == TET_UNKNOWN_METHOD ? RPCStatusMethodNotFound
-															  : RPCStatusMetaError);
-				error_ = ex.type;
-				errmsg_ = ex.message;
-			}
-			else
-			{
-				status_code_ = RPCStatusMetaError;
-				error_ = TET_INTERNAL_ERROR;
-				errmsg_ = this->get_errmsg();
-			}
-		}
-
-		return true;
-	}
-
-	return false;
-}
-
-const char *ThriftResponse::get_errmsg() const
-{
-	switch (status_code_)
+	switch (error)
 	{
 	case TET_UNKNOWN:
 		return "TApplicationException: Unknown application exception";
@@ -184,6 +155,44 @@ const char *ThriftResponse::get_errmsg() const
 	default:
 		return "TApplicationException: (Invalid exception type)";
 	};
+}
+
+
+bool ThriftResponse::deserialize_meta()
+{
+	if (TBuffer_.readMessageBegin())
+	{
+		if (TBuffer_.meta.message_type == TMT_EXCEPTION)
+		{
+			ThriftException ex;
+
+			if (ex.descriptor->reader(&TBuffer_, &ex))
+			{
+				status_code_ = (ex.type == TET_UNKNOWN_METHOD ? RPCStatusMethodNotFound
+															  : RPCStatusMetaError);
+				error_ = ex.type;
+				errmsg_ = ex.message;
+			}
+			else
+			{
+				status_code_ = RPCStatusMetaError;
+				error_ = TET_INTERNAL_ERROR;
+				errmsg_ = thrift_error2errmsg(error_);
+			}
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+const char *ThriftResponse::get_errmsg() const
+{
+	if (! errmsg_.empty()) {
+		return errmsg_.c_str();
+	}
+	return thrift_error2errmsg(error_);
 }
 
 bool ThriftHttpRequest::serialize_meta()

--- a/src/message/rpc_message_thrift.h
+++ b/src/message/rpc_message_thrift.h
@@ -134,8 +134,6 @@ public:
 	void set_status_code(int code)
 	{
 		status_code_ = code;
-		if (code != RPCStatusOK)
-			errmsg_ = this->get_errmsg();
 	}
 
 	void set_error(int error) { error_ = error; }


### PR DESCRIPTION
1、fix：thrift协议返回给client的context中，get_errmsg()接口里的异常信息错误。
2、fix：parser解析thrift map类型，第二个valkey解析出来少头一个字符。