### PR TITLE
fix(generator): Fix segmentation fault when thrift idl file generator…

### DIFF
--- a/src/generator/generator.cc
+++ b/src/generator/generator.cc
@@ -105,20 +105,28 @@ bool Generator::generate_header(idl_info& cur_info, struct GeneratorParams param
 	{
 		fprintf(stdout, "[Generator] auto generate include file [%s]\n",
 				sub_info.absolute_file_path.c_str());
-		this->generate_header(sub_info, params);
+		if (!this->generate_header(sub_info, params))
+			return false;
 	}
 
 	// for protobuf: if no [rpc], don`t need to generate xxx.srpc.h
 	if (this->init_file_names(cur_info.absolute_file_path, params.out_dir) == false)
 	{
 		fprintf(stderr, "[Generator Error] parse proto output dir failed. %s %s\n",
-				cur_info.absolute_file_path.c_str(), params.out_dir);	
+				cur_info.absolute_file_path.c_str(), params.out_dir);
 		return false;
 	}
 
 	// will generate skeleton file only once
 	if (this->is_thrift)
-		this->generate_thrift_type_file(cur_info);//[prefix].thrift.h
+	{
+		//[prefix].thrift.h
+		if (!this->generate_thrift_type_file(cur_info))
+		{
+			fprintf(stderr, "[Generator Error] generate thrift type file failed\n");
+			return false;
+		}
+	}
 
 	for (const auto& desc : this->info.desc_list)
 	{
@@ -228,9 +236,16 @@ void Generator::thrift_replace_include(const idl_info& cur_info, std::vector<rpc
 	}
 }
 
-void Generator::generate_thrift_type_file(idl_info& cur_info)
+bool Generator::generate_thrift_type_file(idl_info& cur_info)
 {
-	this->printer.open(this->thrift_type_file);
+
+	if (!this->printer.open(this->thrift_type_file))
+	{
+		fprintf(stderr, "[Generator Error] can't write to thirft_type_file: %s\n",
+				this->thrift_type_file.c_str());
+		return false;
+	}
+
 	this->printer.print_thrift_include(cur_info);
 
 	for (auto& desc : cur_info.desc_list)
@@ -261,6 +276,7 @@ void Generator::generate_thrift_type_file(idl_info& cur_info)
 
 	this->printer.print_end(cur_info.package_name);
 	this->printer.close();
+	return true;
 }
 
 void Generator::generate_srpc_file(const idl_info& cur_info)

--- a/src/generator/generator.cc
+++ b/src/generator/generator.cc
@@ -123,7 +123,7 @@ bool Generator::generate_header(idl_info& cur_info, struct GeneratorParams param
 		//[prefix].thrift.h
 		if (!this->generate_thrift_type_file(cur_info))
 		{
-			fprintf(stderr, "[Generator Error] generate thrift type file failed\n");
+			fprintf(stderr, "[Generator Error] generate thrift type file failed.\n");
 			return false;
 		}
 	}
@@ -241,7 +241,7 @@ bool Generator::generate_thrift_type_file(idl_info& cur_info)
 
 	if (!this->printer.open(this->thrift_type_file))
 	{
-		fprintf(stderr, "[Generator Error] can't write to thirft_type_file: %s\n",
+		fprintf(stderr, "[Generator Error] can't write to thirft_type_file: %s.\n",
 				this->thrift_type_file.c_str());
 		return false;
 	}

--- a/src/generator/generator.h
+++ b/src/generator/generator.h
@@ -55,7 +55,7 @@ private:
 	void generate_skeleton(const std::string& idl_file);
 
 	void generate_srpc_file(const idl_info& cur_info);
-	void generate_thrift_type_file(idl_info& cur_info);
+	bool generate_thrift_type_file(idl_info& cur_info);
 	void generate_server_cpp_file(const idl_info& cur_info, const std::string& idle_file_name);
 	void generate_client_cpp_file(const idl_info& cur_info, const std::string& idle_file_name);
 	void thrift_replace_include(const idl_info& cur_info, std::vector<rpc_param>& params);

--- a/src/generator/printer.h
+++ b/src/generator/printer.h
@@ -259,7 +259,7 @@ public:
 	bool open(std::string out_file)
 	{
 		this->out_file = fopen(out_file.c_str(), "w");
-		return !this->out_file;
+		return this->out_file;
 	}
 
 	void close()


### PR DESCRIPTION
… can't open output directory

Generator will end up with segmentation fault when the output directory doesn't exist. eg: In following bash command, "xxx" is invalid.

```
ubuntu@VM-0-3-ubuntu:~/srpc/test$ ../bazel-bin/src/generator/compiler thrift ./test_thrift.thrift  xxx
[Generator Begin]
proto file: [/home/ubuntu/srpc/test/test_thrift.thrift]
Successfully parse service block [service] : TestThrift
Successfully parse method:add req:addRequest resp:addResponse
Successfully parse method:substr req:substrRequest resp:substrResponse
[Generator] generate srpc files: xxx/test_thrift.thrift.srpc.h xxx/test_thrift.thrift.h
Segmentation fault
```

This PR fixes the above bug, avoid segfault, generator error information below:

```
ubuntu@VM-0-3-ubuntu:~/srpc/test$ ../bazel-bin/src/generator/compiler thrift ./test_thrift.thrift  xxx
[Generator Begin]
proto file: [/home/ubuntu/srpc/test/test_thrift.thrift]
Successfully parse service block [service] : TestThrift
Successfully parse method:add req:addRequest resp:addResponse
Successfully parse method:substr req:substrRequest resp:substrResponse
[Generator] generate srpc files: xxx/test_thrift.srpc.h xxx/test_thrift.thrift.h
[Generator Error] can't write to thirft_type_file: xxx/test_thrift.thrift.h
[Generator Error] generate thrift type file failed
[Generator Error] generate failed.
[Generator Done]
```