### PR TITLE
thrift parser optimization

### DIFF
--- a/src/generator/generator.cc
+++ b/src/generator/generator.cc
@@ -232,6 +232,8 @@ void Generator::generate_thrift_type_file(idl_info& cur_info)
 {
 	this->printer.open(this->thrift_type_file);
 	this->printer.print_thrift_include(cur_info);
+	this->printer.print_thrift_typedef(cur_info);
+	this->printer.print_thrift_struct_declaration(cur_info);
 
 	for (auto& desc : cur_info.desc_list)
 	{
@@ -241,9 +243,9 @@ void Generator::generate_thrift_type_file(idl_info& cur_info)
 			for (auto& rpc : desc.rpcs)
 			{
 				this->thrift_replace_include(cur_info, rpc.req_params);
-				this->printer.print_rpc_thrift_struct_class(rpc.request_name, rpc.req_params);
+				this->printer.print_rpc_thrift_struct_class(rpc.request_name, rpc.req_params,cur_info);
 				this->thrift_replace_include(cur_info, rpc.resp_params);
-				this->printer.print_rpc_thrift_struct_class(rpc.response_name, rpc.resp_params);
+				this->printer.print_rpc_thrift_struct_class(rpc.response_name, rpc.resp_params,cur_info);
 			}
 
 			this->printer.print_service_namespace_end(desc.block_name);
@@ -251,7 +253,7 @@ void Generator::generate_thrift_type_file(idl_info& cur_info)
 		else if (desc.block_type == "struct")
 		{
 			this->thrift_replace_include(cur_info, desc.st.params);
-			this->printer.print_rpc_thrift_struct_class(desc.block_name, desc.st.params);
+			this->printer.print_rpc_thrift_struct_class(desc.block_name, desc.st.params,cur_info);
 		}
 		else if (desc.block_type == "enum")
 		{

--- a/src/generator/parser.cc
+++ b/src/generator/parser.cc
@@ -315,27 +315,7 @@ std::string Parser::find_typedef_mapping_type(std::string& type_name,size_t& cur
 		real_type_name = idl_type.substr(pos+2);
 		type_namespace = idl_type.substr(0,pos);
 	}
-/*
-	if (type_namespace != "") 
-	{
-		idl_info *include_info = search_namespace(info,type_namespace);
-		if (include_info == NULL) 
-		{
-			fprintf(stderr,"namespace of type %s not found\n",idl_type.c_str());
-			return idl_type; 
-		}
-		for (auto& t : include_info->typedef_list)
-		{
-			if (real_type_name  == t.new_type_name)
-			{
-				size_t offset = 0;
-				include_info->typedef_mapping[real_type_name] = find_typedef_mapping_type(t.old_type_name,offset,*include_info);
-				return include_info->typedef_mapping[real_type_name];
-			}
-		}
-		return idl_type; 
-	}
-*/
+
 	for (auto& include : info.include_list)
 	{
 		if ( (type_namespace != "" && include.package_name.size() > 0 && include.package_name[0] == type_namespace)
@@ -352,25 +332,6 @@ std::string Parser::find_typedef_mapping_type(std::string& type_name,size_t& cur
 			}
 		}
 	}
-
-	/*
-	//include_file has no namespace
-	if (pos == 0)
-	{
-		for (auto& include : info.include_list)
-		{
-			for (auto& t : include.typedef_list)
-			{
-				if (real_type_name  == t.new_type_name)
-				{
-					size_t offset = 0;
-					include.typedef_mapping[real_type_name] = find_typedef_mapping_type(t.old_type_name,offset,include);
-					return include.typedef_mapping[real_type_name];
-				}
-			}
-		}
-	}
-	*/
 
 	for (auto& t : info.typedef_list)
 	{

--- a/src/generator/parser.cc
+++ b/src/generator/parser.cc
@@ -20,6 +20,23 @@
 
 #define LINE_MAX 2048
 
+
+static std::string gen_param_var(const std::string& type_name, size_t& cur, idl_info& info);
+std::string type_prefix_to_namespace(const std::string& type_name, idl_info& info);
+Descriptor * search_cur_file_descriptor( idl_info& info,
+										const std::string& block_type, 
+										const std::string& block_name);
+Descriptor * search_include_file_descriptor( idl_info& info,
+											const std::string include_file_name,
+											const std::string& block_type,
+											const std::string& block_name);
+idl_info * search_include_file( idl_info& info, const std::string file_name);
+idl_info * search_namespace( idl_info& info, const std::string name_space);
+void parse_thrift_type_name(const std::string& type_name,
+									std::string& type_prefix,
+									std::string& real_type_name);
+
+
 bool Parser::parse(const std::string& proto_file, idl_info& info)
 {
 	std::string dir_prefix;
@@ -57,6 +74,11 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 	int stack_count = 0;
 	std::string block_name;
 	std::string block_type;
+	std::string extends_type;
+	std::string old_type_name;
+	std::string new_type_name;
+	std::string thrift_type_prefix;
+	std::string thrift_type_name;
 	bool succ;
 
 	while (fgets(line_buffer, LINE_MAX, in))
@@ -70,6 +92,7 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 		if (line.empty())
 			continue;
 
+		this->check_single_comments(line);
 		if ((state & PARSER_ST_COMMENT_MASK) == PARSER_ST_INSIDE_COMMENT)
 		{
 			if (this->check_multi_comments_end(line)) 
@@ -118,6 +141,12 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 			continue;
 		}
 
+		if (this->is_thrift && this->parse_thrift_typedef(line,old_type_name,new_type_name,info) == true)
+		{
+			info.typedef_list.push_back(typedef_descriptor{old_type_name,new_type_name});
+			continue;
+		}
+
 		flag_append = false;
 
 		if ((state & PARSER_ST_BLOCK_MASK) == PARSER_ST_OUTSIDE_BLOCK)
@@ -129,7 +158,7 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 				block.clear();
 				block = line;
 				if (this->parse_block_name(line, block_type,
-										   block_name) == false)
+										   block_name,extends_type) == false)
 				{
 					fprintf(stderr, "Invalid proto file line: %s\n", line.c_str());
 					fprintf(stderr, "Failed to parse block name or value.\n");
@@ -160,7 +189,7 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 					{
 						Descriptor desc;
 						if (this->is_thrift)
-							succ = this->parse_service_thrift(info.file_name_prefix, block, desc);
+							succ = this->parse_service_thrift(info.file_name_prefix, block, desc, info);
 						else
 							succ = this->parse_service_pb(block, desc);
 
@@ -169,12 +198,32 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 
 						desc.block_type = block_type;
 						desc.block_name = block_name;
+						desc.extends_type = extends_type;
+						if (desc.extends_type != "" && this->is_thrift)
+						{
+							Descriptor *extended_desc = NULL; 			
+							parse_thrift_type_name(desc.extends_type,
+													thrift_type_prefix,thrift_type_name);
+							if (thrift_type_prefix == "")
+								extended_desc = search_cur_file_descriptor(info,
+													"service",thrift_type_name);
+							else 
+								extended_desc = search_include_file_descriptor(info,
+													thrift_type_prefix+".thrift","service",thrift_type_name);
+							if (!extended_desc)
+								fprintf(stderr,"service %s extends type %s not found\n",
+											desc.block_name.c_str(),desc.extends_type.c_str());
+							else
+								desc.rpcs.insert(desc.rpcs.begin(),
+											extended_desc->rpcs.begin(),extended_desc->rpcs.end());
+						}
+
 						info.desc_list.emplace_back(std::move(desc));
 					}
 					else if (block_type == "struct" && this->is_thrift)
 					{
 						Descriptor desc;
-						succ = this->parse_struct_thrift(info.file_name_prefix, block, desc);
+						succ = this->parse_struct_thrift(info.file_name_prefix, block, desc, info);
 						if (!succ)
 							return false;
 
@@ -182,6 +231,17 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 						desc.block_name = block_name;
 						info.desc_list.emplace_back(std::move(desc));
 
+					}
+					else if (block_type == "exception" && this->is_thrift)
+					{
+						Descriptor desc;
+						succ = this->parse_struct_thrift(info.file_name_prefix, block, desc, info);
+						if (!succ)
+							return false;
+
+						desc.block_type = "struct";
+						desc.block_name = block_name;
+						info.desc_list.emplace_back(std::move(desc));
 					}
 					else if (block_type == "enum" && this->is_thrift)
 					{
@@ -199,10 +259,157 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 			}
 		}
 	}
-
+	build_typedef_mapping(info);
 	fclose(in);
 	return true;
 }
+
+std::string Parser::find_typedef_mapping_type(std::string& type_name,size_t& cur, idl_info& info)
+{
+	size_t st = cur;
+	cur = SGenUtil::find_next_nonspace(type_name,cur);
+	for (; cur < type_name.size(); cur++)
+	{
+		if (type_name[cur] == ',' || type_name[cur] == '>' || type_name[cur] == '<')
+			break;
+	}
+
+	auto idl_type = SGenUtil::strip(type_name.substr(st, cur - st));
+
+	if (info.typedef_mapping.find(idl_type) != info.typedef_mapping.end())
+		return info.typedef_mapping[idl_type];
+
+	if (idl_type == "bool" ||
+		idl_type == "int8_t" ||
+		idl_type == "int16_t" ||
+		idl_type == "int32_t" ||
+		idl_type == "int64_t" ||
+		idl_type == "uint64_t" ||
+		idl_type == "double" ||
+		idl_type == "std::string" )
+		return idl_type;
+	else if (idl_type == "std::map" && cur < type_name.size() && type_name[cur] == '<')
+	{
+		auto key_type = find_typedef_mapping_type(type_name, ++cur, info);
+		auto val_type = find_typedef_mapping_type(type_name, ++cur, info);
+		return "std::map<" + key_type + ", " + val_type + ">";
+	}
+	else if (idl_type == "std::set" && cur < type_name.size() && type_name[cur] == '<')
+	{
+		auto val_type = find_typedef_mapping_type(type_name, ++cur, info);
+		return "std::set<" + val_type + ">";
+	}
+	else if (idl_type == "std::vector" && cur < type_name.size() && type_name[cur] == '<')
+	{
+		auto val_type = find_typedef_mapping_type(type_name, ++cur, info);
+		return "std::vector<" + val_type + ">";
+	}
+
+	size_t pos = idl_type.find("::",0);
+	std::string real_type_name;
+	std::string type_namespace;
+	if (pos == std::string::npos)
+		real_type_name = idl_type;
+	else
+	{
+		real_type_name = idl_type.substr(pos+2);
+		type_namespace = idl_type.substr(0,pos);
+	}
+/*
+	if (type_namespace != "") 
+	{
+		idl_info *include_info = search_namespace(info,type_namespace);
+		if (include_info == NULL) 
+		{
+			fprintf(stderr,"namespace of type %s not found\n",idl_type.c_str());
+			return idl_type; 
+		}
+		for (auto& t : include_info->typedef_list)
+		{
+			if (real_type_name  == t.new_type_name)
+			{
+				size_t offset = 0;
+				include_info->typedef_mapping[real_type_name] = find_typedef_mapping_type(t.old_type_name,offset,*include_info);
+				return include_info->typedef_mapping[real_type_name];
+			}
+		}
+		return idl_type; 
+	}
+*/
+	for (auto& include : info.include_list)
+	{
+		if ( (type_namespace != "" && include.package_name.size() > 0 && include.package_name[0] == type_namespace)
+					|| (type_namespace == "" && include.package_name.size() == 0) )
+		{
+			for (auto& t : include.typedef_list)
+			{
+				if (real_type_name  == t.new_type_name)
+				{
+					size_t offset = 0;
+					include.typedef_mapping[real_type_name] = find_typedef_mapping_type(t.old_type_name,offset,include);
+					return include.typedef_mapping[real_type_name];
+				}
+			}
+		}
+	}
+
+	/*
+	//include_file has no namespace
+	if (pos == 0)
+	{
+		for (auto& include : info.include_list)
+		{
+			for (auto& t : include.typedef_list)
+			{
+				if (real_type_name  == t.new_type_name)
+				{
+					size_t offset = 0;
+					include.typedef_mapping[real_type_name] = find_typedef_mapping_type(t.old_type_name,offset,include);
+					return include.typedef_mapping[real_type_name];
+				}
+			}
+		}
+	}
+	*/
+
+	for (auto& t : info.typedef_list)
+	{
+		if (real_type_name  == t.new_type_name)
+		{
+			size_t offset = 0;
+			info.typedef_mapping[real_type_name] = find_typedef_mapping_type(t.old_type_name,offset,info);
+			return info.typedef_mapping[real_type_name];
+		}
+	}
+
+	return idl_type;
+}
+
+
+void Parser::build_typedef_mapping(idl_info& info)
+{
+	for(auto &include:info.include_list)
+	{
+		for(auto &t:include.typedef_list)
+		{
+			if (include.typedef_mapping.find(t.new_type_name) != include.typedef_mapping.end())
+				continue;
+			size_t cur = 0;
+			include.typedef_mapping[t.new_type_name] = find_typedef_mapping_type(t.old_type_name,cur,include);
+//			fprintf(stdout,"%s %s\n",t.new_type_name.c_str(),include.typedef_mapping[t.new_type_name].c_str());
+		}
+	}
+	
+	for(auto &t:info.typedef_list)
+	{
+		if (info.typedef_mapping.find(t.new_type_name) != info.typedef_mapping.end())
+			continue;
+		size_t cur = 0;
+		info.typedef_mapping[t.new_type_name] = find_typedef_mapping_type(t.old_type_name,cur,info);
+//		fprintf(stdout,"%s %s\n",t.new_type_name.c_str(),info.typedef_mapping[t.new_type_name].c_str());
+	}
+}
+
 
 // check / * and cut the first available line
 bool Parser::check_multi_comments_begin(std::string& line)
@@ -258,6 +465,22 @@ bool Parser::parse_dir_prefix(const std::string& file_name, char *dir_prefix)
 	snprintf(dir_prefix, pos + 2, "%s", file_name.c_str());
 //	fprintf(stderr, "[%s]------------[%s]\n", file_name.c_str(), dir_prefix);
 	return true;
+}
+
+bool Parser::parse_thrift_typedef(const std::string& line, std::string& old_type_name, std::string& new_type_name, idl_info&info)
+{
+	std::vector<std::string> elems = SGenUtil::split_by_space(line);
+	if (elems.size() >= 3 && elems[0] == "typedef")
+	{
+		size_t offset = 0;
+		std::string idl_type;
+		for (size_t i = 1; i < elems.size()-1; i++)
+			idl_type.append(elems[i]);
+		old_type_name = gen_param_var(idl_type,offset,info);
+		new_type_name = elems[elems.size()-1];
+		return true;
+	}
+	return false;
 }
 
 bool Parser::parse_include_file(const std::string& line, std::string& file_name)
@@ -353,10 +576,10 @@ bool Parser::parse_package_name(const std::string& line,
 	return true;
 }
 
-static std::string gen_param_var(const std::string& type_name, size_t& cur)
+static std::string gen_param_var(const std::string& type_name, size_t& cur, idl_info& info)
 {
 	size_t st = cur;
-
+	cur = SGenUtil::find_next_nonspace(type_name,cur);
 	for (; cur < type_name.size(); cur++)
 	{
 		if (type_name[cur] == ',' || type_name[cur] == '>' || type_name[cur] == '<')
@@ -383,26 +606,27 @@ static std::string gen_param_var(const std::string& type_name, size_t& cur)
 		return "std::string";
 	else if (idl_type == "map" && cur < type_name.size() && type_name[cur] == '<')
 	{
-		auto key_type = gen_param_var(type_name, ++cur);
-		auto val_type = gen_param_var(type_name, ++cur);
+		auto key_type = gen_param_var(type_name, ++cur, info);
+		auto val_type = gen_param_var(type_name, ++cur, info);
 		return "std::map<" + key_type + ", " + val_type + ">";
 	}
 	else if (idl_type == "set" && cur < type_name.size() && type_name[cur] == '<')
 	{
-		auto val_type = gen_param_var(type_name, ++cur);
+		auto val_type = gen_param_var(type_name, ++cur, info);
 		return "std::set<" + val_type + ">";
 	}
 	else if (idl_type == "list" && cur < type_name.size() && type_name[cur] == '<')
 	{
-		auto val_type = gen_param_var(type_name, ++cur);
+		auto val_type = gen_param_var(type_name, ++cur, info);
 		return "std::vector<" + val_type + ">";
 	}
 
-	return idl_type;
+	return type_prefix_to_namespace(idl_type, info);
 }
 
 static void fill_rpc_param_type(const std::string& file_name_prefix,
-								const std::string& idl_type, rpc_param& param)
+								const std::string idl_type, 
+								rpc_param& param, idl_info& info)
 {
 	if (idl_type == "bool")
 	{
@@ -448,19 +672,19 @@ static void fill_rpc_param_type(const std::string& file_name_prefix,
 	{
 		size_t cur = 0;
 		param.data_type = srpc::TDT_LIST;
-		param.type_name = gen_param_var(idl_type, cur);
+		param.type_name = gen_param_var(idl_type, cur, info);
 	}
 	else if (SGenUtil::start_with(idl_type, "map"))
 	{
 		size_t cur = 0;
 		param.data_type = srpc::TDT_MAP;
-		param.type_name = gen_param_var(idl_type, cur);
+		param.type_name = gen_param_var(idl_type, cur, info);
 	}
 	else if (SGenUtil::start_with(idl_type, "set"))
 	{
 		size_t cur = 0;
 		param.data_type = srpc::TDT_SET;
-		param.type_name = gen_param_var(idl_type, cur);
+		param.type_name = gen_param_var(idl_type, cur, info);
 	}
 	else
 	{
@@ -475,12 +699,79 @@ static void fill_rpc_param_type(const std::string& file_name_prefix,
 		{
 			//struct
 			param.data_type = srpc::TDT_STRUCT;
-			param.type_name = idl_type;
+			param.type_name = type_prefix_to_namespace(idl_type,info);
 		}
 	}
 }
 
-bool Parser::parse_service_thrift(const std::string& file_name_prefix, const std::string& block, Descriptor& desc)
+std::vector<std::string> Parser::split_thrift_rpc(const std::string& str)
+{
+	std::vector<std::string> res;
+	std::string::const_iterator start = str.begin();
+	std::string::const_iterator parameter_end = str.end();
+	std::string::const_iterator throws_end = str.end();
+	while(1) 
+	{
+		parameter_end = find(start,str.end(),')');
+		if (parameter_end == str.end()) 
+		{	
+			res.emplace_back(start,parameter_end);
+			break;
+		}
+		
+		std::string::const_iterator	offset = find_if(parameter_end+1,str.end(),
+					[](char c){return !std::isspace(c);});
+		if (offset == str.end())
+		{
+			res.emplace_back(start,parameter_end);
+			break;
+		}
+		
+		if (str.compare(offset-str.begin(),6,"throws") == 0) 
+		{
+			throws_end = find(offset,str.end(),')');
+			res.emplace_back(start,throws_end);
+			start = throws_end+1;
+		}
+		else
+		{
+			res.emplace_back(start,parameter_end);
+			start = parameter_end+1;
+		}
+	}
+	return res;
+}
+
+bool Parser::parse_rpc_param_thrift(const std::string& file_name_prefix,const std::string& str, std::vector<rpc_param>& params, idl_info& info)
+{
+	size_t left_b = 0;
+	rpc_param param;
+	std::string idl_type;
+	if (left_b + 1 < str.size())
+	{
+		auto bb = SGenUtil::split_filter_empty(str.substr(left_b + 1), ',');
+		for (const auto& ele : bb)
+		{
+			auto filedparam = SGenUtil::split_filter_empty(ele, ':');
+			if (filedparam.size() != 2)
+			  continue;
+
+			auto typevar = SGenUtil::split_filter_empty(filedparam[1], ' ');
+			if (typevar.size() != 2)
+			  continue;
+
+			param.var_name = typevar[1];
+			param.required_state = srpc::THRIFT_STRUCT_FIELD_REQUIRED;
+			param.field_id = atoi(SGenUtil::strip(filedparam[0]).c_str());
+			idl_type = SGenUtil::strip(typevar[0]);
+			fill_rpc_param_type(file_name_prefix, idl_type, param, info);
+			params.push_back(param);
+		}
+	}
+	return true;
+}
+
+bool Parser::parse_service_thrift(const std::string& file_name_prefix, const std::string& block, Descriptor& desc, idl_info& info)
 {
 	rpc_descriptor rpc_desc;
 	auto st = block.find_first_of('{');
@@ -489,12 +780,11 @@ bool Parser::parse_service_thrift(const std::string& file_name_prefix, const std
 		return false;
 
 	std::string valid_block = block.substr(st + 1, ed - st - 1);
-	auto arr = SGenUtil::split_filter_empty(valid_block, ')');
+	auto arr = split_thrift_rpc(valid_block);
 
 	for (const auto& ele : arr)
 	{
 		auto line = SGenUtil::strip(ele);
-
 		size_t i = 0;
 		for (; i < line.size(); i++)
 		{
@@ -533,32 +823,26 @@ bool Parser::parse_service_thrift(const std::string& file_name_prefix, const std
 		param.field_id = 0;
 		if (idl_type != "void")
 		{
-			fill_rpc_param_type(file_name_prefix, idl_type, param);
+			fill_rpc_param_type(file_name_prefix, idl_type, param, info);
 			rpc_desc.resp_params.push_back(param);
 		}
 
-		if (left_b + 1 < line.size())
+		auto right_b = line.find(')',left_b);
+		if (right_b == std::string::npos)
 		{
-			auto bb = SGenUtil::split_filter_empty(line.substr(left_b + 1), ',');
-			for (const auto& ele : bb)
+			parse_rpc_param_thrift(file_name_prefix,line.substr(left_b),rpc_desc.req_params,info);
+		}
+		else
+		{
+			parse_rpc_param_thrift(file_name_prefix,line.substr(left_b,right_b-left_b),rpc_desc.req_params,info);
+			auto throws_start = line.find("throws",right_b);
+			if (throws_start != std::string::npos) 
 			{
-				auto filedparam = SGenUtil::split_filter_empty(ele, ':');
-				if (filedparam.size() != 2)
-					continue;
-
-				auto typevar = SGenUtil::split_filter_empty(filedparam[1], ' ');
-				if (typevar.size() != 2)
-					continue;
-
-				param.var_name = typevar[1];
-				param.required_state = srpc::THRIFT_STRUCT_FIELD_REQUIRED;
-				param.field_id = atoi(SGenUtil::strip(filedparam[0]).c_str());
-				idl_type = SGenUtil::strip(typevar[0]);
-				fill_rpc_param_type(file_name_prefix, idl_type, param);
-				rpc_desc.req_params.push_back(param);
+				left_b = line.find('(',throws_start+6); 	
+				parse_rpc_param_thrift(file_name_prefix,line.substr(left_b),rpc_desc.resp_params,info);
 			}
 		}
-
+	
 		fprintf(stdout, "Successfully parse method:%s req:%s resp:%s\n",
 				rpc_desc.method_name.c_str(),
 				rpc_desc.request_name.c_str(),
@@ -610,7 +894,8 @@ bool Parser::parse_enum_thrift(const std::string& block, Descriptor& desc)
 }
 
 bool Parser::parse_struct_thrift(const std::string& file_name_prefix,
-								 const std::string& block, Descriptor& desc)
+								 const std::string& block,
+								 Descriptor& desc, idl_info& info)
 {
 	rpc_param param;
 	auto st = block.find_first_of('{');
@@ -698,7 +983,7 @@ bool Parser::parse_struct_thrift(const std::string& file_name_prefix,
 
 		param.var_name = b3;
 
-		fill_rpc_param_type(file_name_prefix, b2, param);
+		fill_rpc_param_type(file_name_prefix, b2, param, info);
 		fprintf(stdout, "Successfully parse struct param: %s %s\n",
 				param.type_name.c_str(), param.var_name.c_str());
 		desc.st.params.push_back(param);
@@ -791,6 +1076,42 @@ bool Parser::parse_service_pb(const std::string& block, Descriptor& desc)
 
 bool Parser::parse_block_name(const std::string& line,
 							  std::string& block_name,
+							  std::string& block_name_value,
+							  std::string& extends_type)
+{
+	size_t pos = line.find("{");
+	if (pos == std::string::npos)
+	{
+		fprintf(stderr, "failed to parse block name in %s\n",line.c_str());
+		return false;
+	}
+
+	std::vector<std::string> elems = SGenUtil::split_by_space(line.substr(0,pos));
+	if (elems.size() == 2)
+	{
+		block_name = elems[0];
+		block_name_value = elems[1];
+		extends_type = "";
+	}
+	else if (this->is_thrift && elems.size() == 4 && elems[0] == "service" && elems[2] == "extends")
+	{
+		block_name = elems[0];
+		block_name_value = elems[1];
+		extends_type = elems[3];
+	}
+	else 
+	{
+		fprintf(stderr, "failed to parse block name in %s\n", line.c_str());
+		return false;
+	}
+	fprintf(stdout, "Successfully parse service block [%s] : %s\n",
+			block_name.c_str(), block_name_value.c_str());
+	return true;
+}
+
+/*
+bool Parser::parse_block_name(const std::string& line,
+							  std::string& block_name,
 							  std::string& block_name_value)
 {
 	size_t pos = line.find_first_of(" ", 0);
@@ -823,6 +1144,7 @@ bool Parser::parse_block_name(const std::string& line,
 			block_name.c_str(), block_name_value.c_str());
 	return true;
 }
+*/
 
 bool Parser::check_block_begin(FILE *in, std::string& line)
 {
@@ -860,6 +1182,89 @@ bool Parser::check_block_end(const std::string& line)
 		return false;
 	return true;
 }
+
+void parse_thrift_type_name(const std::string& type_name,
+									std::string& type_prefix,
+									std::string& real_type_name)
+{
+	size_t pos = type_name.find('.',0);
+	if (pos == std::string::npos)
+	{
+		type_prefix = "";
+		real_type_name = SGenUtil::strip(type_name);
+	}
+	else 
+	{
+		type_prefix = SGenUtil::strip(type_name.substr(0,pos));	
+		real_type_name = SGenUtil::strip(type_name.substr(pos+1));
+	}
+}
+
+std::string type_prefix_to_namespace(const std::string& type_name, idl_info& info)
+{
+	std::string prefix;
+	std::string real_type;
+	parse_thrift_type_name(type_name,prefix,real_type);
+	if (prefix == "")
+		return type_name;
+	idl_info *include = search_include_file(info,prefix+".thrift");
+	if (include == NULL)
+	{
+		fprintf(stderr,"cannot find type %s\n",type_name.c_str());
+		return type_name;
+	}
+	if (include->package_name.size() > 0)
+		return include->package_name[0]+"::"+real_type;
+	return "::"+real_type;
+}
+
+Descriptor * search_cur_file_descriptor( idl_info& info,
+										const std::string& block_type,
+										const std::string& block_name)
+{
+	for (auto &desc : info.desc_list)
+	{
+		if (desc.block_type == block_type && desc.block_name == block_name)
+			return &desc;
+	}
+	return NULL;
+}
+
+Descriptor * search_include_file_descriptor( idl_info& info,
+											const std::string include_file_name,
+											const std::string& block_type,
+											const std::string& block_name)
+{
+	for (auto &include : info.include_list)
+	{
+		if (include.file_name == include_file_name)
+			return search_cur_file_descriptor(include,block_type,block_name);
+	}
+	return NULL;
+}
+
+idl_info * search_include_file( idl_info& info, const std::string file_name)
+{
+	for (auto &include : info.include_list)
+	{
+		if (include.file_name == file_name)
+			return &include;
+	}
+	return NULL;
+}
+idl_info * search_namespace( idl_info& info, const std::string name_space)
+{
+	if (name_space == "")
+		return &info;
+	for (auto &include : info.include_list)
+	{
+		if (include.package_name.size() > 0 and include.package_name[0] == name_space)
+			return &include;
+	}
+	return NULL;
+}
+
+
 
 int Parser::find_valid(const std::string& line)
 {

--- a/src/generator/parser.h
+++ b/src/generator/parser.h
@@ -45,7 +45,9 @@ class Parser
 {
 public:
 	bool parse(const std::string& proto_file, idl_info& info);
-
+	std::string find_typedef_mapping_type(std::string& type_name,
+											size_t& cur, idl_info& info);
+	void build_typedef_mapping(idl_info& info);
 	int find_valid(const std::string& line);
 	bool check_block_begin(FILE *in, std::string& line);
 	bool check_block_begin(const std::string& line);
@@ -53,12 +55,25 @@ public:
 	void check_single_comments(std::string& line);
 	bool parse_block_name(const std::string& line,
 						  std::string& block_name,
-						  std::string& block_name_value);
+						  std::string& block_name_value,
+						  std::string& extend_type);
 	bool parse_service_pb(const std::string& block, Descriptor& desc);
+	std::vector<std::string> split_thrift_rpc(const std::string &str);
+	bool parse_thrift_typedef(const std::string& line, 
+							std::string& old_type_name,
+							std::string& new_type_name,
+							idl_info& info);
+	bool parse_rpc_param_thrift(const std::string& file_name_prefix,
+								const std::string &str, 
+								std::vector<rpc_param> &params,
+								idl_info& info);
 	bool parse_service_thrift(const std::string& file_name_prefix,
-							  const std::string& block, Descriptor& desc);
+							  const std::string& block, 
+							  Descriptor& desc,
+							  idl_info& info);
 	bool parse_struct_thrift(const std::string& file_name_prefix,
-							 const std::string& block, Descriptor& desc);
+							 const std::string& block,
+							 Descriptor& desc, idl_info& info);
 	bool parse_enum_thrift(const std::string& block, Descriptor& desc);
 	bool parse_package_name(const std::string& line, std::vector<std::string>& package_name);
 	bool parse_include_file(const std::string& line, std::string& file_name);
@@ -66,7 +81,6 @@ public:
 	bool check_multi_comments_end(std::string& line);
 	bool parse_dir_prefix(const std::string& file_name, char *dir_prefix);
 	int parse_pb_rpc_option(const std::string& line);
-
 	Parser(bool is_thrift) { this->is_thrift = is_thrift; }
 
 private:


### PR DESCRIPTION
1、支持exception和throws语法
2、支持extends语法
3、支持typedef语法
4、修复引用头文件中类型时，生成代码没有去掉头文件前缀，没有加namespce的问题
