### PR TITLE
support attributes for module

### DIFF
--- a/src/module/rpc_module_span.h
+++ b/src/module/rpc_module_span.h
@@ -102,7 +102,7 @@ public:
 	{
 		snprintf(this->traceid_pattern, PATTERN_LEN, "%%0%zullx",
 				 SRPC_TRACEID_SIZE);
-		snprintf(this->spanid_pattern, PATTERN_LEN, "%%0%zullx",
+		snprintf(this->spanid_pattern, PATTERN_LEN, "%%0%zux",
 				 SRPC_SPANID_SIZE);
 	}
 

--- a/src/module/rpc_span_policies.cc
+++ b/src/module/rpc_span_policies.cc
@@ -201,7 +201,8 @@ SubTask *RPCSpanOpenTelemetry::create(RPCModuleData& span)
 	return task;
 }
 
-void RPCSpanOpenTelemetry::add_attributes(std::string key, std::string value)
+void RPCSpanOpenTelemetry::add_attributes(const std::string& key,
+										  const std::string& value)
 {
 	this->mutex.lock();
 	this->attributes.emplace(std::move(key), std::move(value));

--- a/src/module/rpc_span_policies.cc
+++ b/src/module/rpc_span_policies.cc
@@ -13,6 +13,8 @@ static size_t rpc_span_pb_format(RPCModuleData& data,
 	opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest& req)
 {
 	using namespace opentelemetry::proto::trace::v1;
+	using namespace opentelemetry::proto::common::v1;
+
 	ResourceSpans *resource_span = req.add_resource_spans();
 	InstrumentationLibrarySpans *ins_lib;
 	ins_lib = resource_span->add_instrumentation_library_spans();
@@ -20,10 +22,9 @@ static size_t rpc_span_pb_format(RPCModuleData& data,
 
 	for (auto attr : attributes)
 	{
-		auto attribute = span->add_attributes();
+		KeyValue *attribute = span->add_attributes();
 		attribute->set_key(attr.first);
-
-		auto value = attribute->mutable_value();
+		AnyValue *value = attribute->mutable_value();
 		value->set_string_value(attr.second);
 	}
 

--- a/src/module/rpc_span_policies.h
+++ b/src/module/rpc_span_policies.h
@@ -206,7 +206,7 @@ public:
 	}
 
 	// for client level attributes, such as ProviderID
-	void add_attributes(std::string key, std::string value);
+	void add_attributes(const std::string& key, const std::string& value);
 	size_t clear_attributes();
 
 private:

--- a/src/module/rpc_span_policies.h
+++ b/src/module/rpc_span_policies.h
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <limits>
+#include <unordered_map>
 #include "workflow/WFTask.h"
 #include "workflow/WFTaskFactory.h"
 #include "workflow/RedisMessage.h"
@@ -210,8 +211,8 @@ public:
 
 private:
 	std::string url;
-	unsigned int redirect_max;
-	unsigned int retry_max;
+	int redirect_max;
+	int retry_max;
 
 	RPCSpanFilterPolicy filter_policy;
 	std::mutex mutex;

--- a/src/module/rpc_span_policies.h
+++ b/src/module/rpc_span_policies.h
@@ -39,10 +39,10 @@ static constexpr size_t			UINT64_STRING_LENGTH		= 20;
 static constexpr unsigned int	SPAN_REDIS_RETRY_MAX		= 0;
 static constexpr const char	   *SPAN_BATCH_LOG_NAME_DEFAULT	= "./span_info.log";
 static constexpr size_t			SPAN_BATCH_LOG_SIZE_DEFAULT	= 4 * 1024 * 1024;
-static constexpr size_t			SPANS_PER_SECOND_DEFAULT	= 1000;
+static constexpr unsigned int	SPANS_PER_SECOND_DEFAULT	= 1000;
 static constexpr const char	   *SPAN_OTLP_TRACES_PATH		= "/v1/traces";
 static constexpr unsigned int	SPAN_HTTP_REDIRECT_MAX		= 0;
-static constexpr unsigned int	SPAN_HTTP_RETRY_MAX			= 0;
+static constexpr unsigned int	SPAN_HTTP_RETRY_MAX			= 1;
 
 class RPCSpanFilterPolicy
 {
@@ -194,39 +194,6 @@ private:
 class RPCSpanOpenTelemetry : public RPCFilter
 {
 public:
-	RPCSpanOpenTelemetry(const std::string& url) :
-		RPCFilter(RPCModuleSpan),
-		url(url + SPAN_OTLP_TRACES_PATH),
-		redirect_max(SPAN_HTTP_REDIRECT_MAX),
-		retry_max(SPAN_HTTP_RETRY_MAX),
-		filter_policy(SPANS_PER_SECOND_DEFAULT)
-	{}
-
-	RPCSpanOpenTelemetry(const std::string& url,
-						 int redirect_max,
-						 int retry_max,
-						 size_t spans_per_second) :
-		RPCFilter(RPCModuleSpan),
-		url(url + SPAN_OTLP_TRACES_PATH),
-		redirect_max(redirect_max),
-		retry_max(retry_max),
-		filter_policy(spans_per_second)
-	{}
-
-private:
-	std::string url;
-	int redirect_max;
-	int retry_max;
-
-private:
-	SubTask *create(RPCModuleData& span) override;
-
-	bool filter(RPCModuleData& span) override
-	{
-		return this->filter_policy.filter(span);
-	}
-
-public:
 	void set_spans_per_sec(size_t n)
 	{
 		this->filter_policy.set_spans_per_sec(n);
@@ -237,8 +204,47 @@ public:
 		this->filter_policy.set_stat_interval(msec);
 	}
 
+	// for client level attributes, such as ProviderID
+	void add_attributes(std::string key, std::string value);
+	size_t clear_attributes();
+
 private:
+	std::string url;
+	unsigned int redirect_max;
+	unsigned int retry_max;
+
 	RPCSpanFilterPolicy filter_policy;
+	std::mutex mutex;
+	std::unordered_map<std::string, std::string> attributes;
+
+private:
+	SubTask *create(RPCModuleData& span) override;
+
+	bool filter(RPCModuleData& span) override
+	{
+		return this->filter_policy.filter(span);
+	}
+
+public:
+	RPCSpanOpenTelemetry(const std::string& url) :
+		RPCFilter(RPCModuleSpan),
+		url(url + SPAN_OTLP_TRACES_PATH),
+		redirect_max(SPAN_HTTP_REDIRECT_MAX),
+		retry_max(SPAN_HTTP_RETRY_MAX),
+		filter_policy(SPANS_PER_SECOND_DEFAULT)
+	{}
+
+	RPCSpanOpenTelemetry(const std::string& url,
+						 unsigned int redirect_max,
+						 unsigned int retry_max,
+						 size_t spans_per_second) :
+		RPCFilter(RPCModuleSpan),
+		url(url + SPAN_OTLP_TRACES_PATH),
+		redirect_max(redirect_max),
+		retry_max(retry_max),
+		filter_policy(spans_per_second)
+	{
+	}
 };
 
 

--- a/tutorial/tutorial-02-srpc_pb_client.cc
+++ b/tutorial/tutorial-02-srpc_pb_client.cc
@@ -28,7 +28,8 @@ int main()
 {
 	Example::SRPCClient client("127.0.0.1", 1412);
 
-	RPCSpanOpenTelemetry span_log("http://127.0.0.1:8080");
+	RPCSpanOpenTelemetry span_log("http://127.0.0.1:4318");
+	span_log.add_attributes("provider.id", "default");
 	client.add_filter(&span_log);
 
 	//async


### PR DESCRIPTION
set module-level attributes, which will be filled into every span:
```cpp
RPCSpanOpenTelemetry span_log("http://127.0.0.1:4318");                     
span_log.add_attributes("provider.id", "default");                          
client.add_filter(&span_log);
```
span info example:
```sh
resource_spans {
  instrumentation_library_spans {
    spans {
      trace_id: "01b55242a7fb0002"
      span_id: "f56577c6"
      name: "Echo"
      kind: SPAN_KIND_CLIENT
      start_time_unix_nano: 1638356939392000
      end_time_unix_nano: 1638356939393000
      attributes {
        key: "provider.id"
        value {
          string_value: "default"
        }
      }
    }
  }
}
```