### PR TITLE
update RPCSpanDefault and update filling trace_id/span_id

### DIFF
--- a/src/message/rpc_message_srpc.cc
+++ b/src/message/rpc_message_srpc.cc
@@ -264,11 +264,17 @@ bool SRPCMessage::set_meta_module_data(const RPCModuleData& data)
 
 	auto iter = data.find("trace_id");
 	if (iter != data.end())
-		meta->mutable_span()->set_trace_id(iter->second.c_str());
+	{
+		meta->mutable_span()->set_trace_id(iter->second.c_str(),
+										   SRPC_TRACEID_SIZE);
+	}
 
 	iter = data.find("span_id");
 	if (iter != data.end())
-		meta->mutable_span()->set_span_id(iter->second.c_str());
+	{
+		meta->mutable_span()->set_span_id(iter->second.c_str(),
+										  SRPC_SPANID_SIZE);
+	}
 	//	meta->mutable_span()->set_parent_span_id(span->parent_span_id);
 	//	name...
 	return true;

--- a/src/module/rpc_module_span.h
+++ b/src/module/rpc_module_span.h
@@ -22,6 +22,8 @@
 #include <limits>
 #include <stdio.h>
 #include <string>
+#include <sys/types.h>
+#include <arpa/inet.h>
 #include "workflow/WFTask.h"
 #include "rpc_basic.h"
 #include "rpc_module.h"
@@ -56,28 +58,27 @@ const char *const SRPC_SAMPLING_PRIO	= "sampling.priority";
 const char *const SRPC_DATA_TYPE		= "data.type";
 const char *const SRPC_COMPRESS_TYPE	= "compress.type";
 
-static inline void rpc_fill_16_bytes(const char *buf,
-									 uint64_t high, uint64_t low)
+#ifndef htonll
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+
+static inline uint64_t htonll(uint64_t x)
 {
-	char *pos = (char *)buf;
-	unsigned char *ptr = ((unsigned char *)&high) + 7;
-
-	for (size_t i = 0; i < 16; i++, ptr--)
-		pos[i] = *ptr;
-
-	ptr = ((unsigned char *)&low) + 7;
-	for (size_t i = 0; i < 16; i++, ptr--)
-		pos[i + 8] = *ptr;
+	return ((uint64_t)htonl(x & 0xFFFFFFFF) << 32) + htonl(x >> 32);
 }
 
-static inline void rpc_fill_8_bytes(const char *buf, uint64_t num)
-{
-	char *pos = (char *)buf;
-	unsigned char *ptr = ((unsigned char *)&num) + 7;
+#elif __BYTE_ORDER == __BIG_ENDIAN
 
-	for (size_t i = 0; i < 16; i++, ptr--)
-		pos[i] = *ptr;
+static inline uint64_t htonll(uint64_t x)
+{
+	return x;
 }
+
+#else
+# error "unknown byte order"
+#endif
+
+#endif
 
 template<class RPCREQ, class RPCRESP>
 class RPCSpanContext : public RPCContextImpl<RPCREQ, RPCRESP>
@@ -189,18 +190,22 @@ bool RPCSpanModule<RPCTYPE>::client_begin(SubTask *task,
 		if (iter != data.end())
 			module_data[SRPC_PARENT_SPAN_ID] = iter->second;
 	} else {
-		uint64_t trace_id_high = SRPCGlobal::get_instance()->get_random();
-		uint64_t trace_id_low = SRPCGlobal::get_instance()->get_random();
+		uint64_t trace_id_high = htonll(SRPCGlobal::get_instance()->get_random());
+		uint64_t trace_id_low = htonll(SRPCGlobal::get_instance()->get_random());
 		std::string trace_id_buf(SRPC_TRACEID_SIZE + 1, 0);
 
-		rpc_fill_16_bytes(trace_id_buf.c_str(), trace_id_high, trace_id_low);
+		memcpy((char *)trace_id_buf.c_str(), &trace_id_high,
+				SRPC_TRACEID_SIZE / 2);
+		memcpy((char *)trace_id_buf.c_str() + SRPC_TRACEID_SIZE / 2,
+				&trace_id_low, SRPC_TRACEID_SIZE / 2);
+
 		module_data[SRPC_TRACE_ID] = std::move(trace_id_buf);
 	}
 
 	uint64_t span_id = SRPCGlobal::get_instance()->get_random();
 	std::string span_id_buf(SRPC_SPANID_SIZE + 1, 0);
 
-	rpc_fill_8_bytes(span_id_buf.c_str(), span_id);
+	memcpy((char *)span_id_buf.c_str(), &span_id, SRPC_SPANID_SIZE);
 	module_data[SRPC_SPAN_ID] = std::move(span_id_buf);
 
 	module_data[SRPC_COMPONENT] = SRPC_COMPONENT_SRPC;
@@ -266,7 +271,11 @@ bool RPCSpanModule<RPCTYPE>::server_begin(SubTask *task,
 		uint64_t trace_id_low = SRPCGlobal::get_instance()->get_random();
 		std::string trace_id_buf(SRPC_TRACEID_SIZE + 1, 0);
 
-		rpc_fill_16_bytes(trace_id_buf.c_str(), trace_id_high, trace_id_low);
+		memcpy((char *)trace_id_buf.c_str(), &trace_id_high,
+				SRPC_TRACEID_SIZE / 2);
+		memcpy((char *)trace_id_buf.c_str() + SRPC_TRACEID_SIZE / 2,
+				&trace_id_low, SRPC_TRACEID_SIZE / 2);
+
 		module_data[SRPC_TRACE_ID] = std::move(trace_id_buf);
 	}
 	else
@@ -275,7 +284,7 @@ bool RPCSpanModule<RPCTYPE>::server_begin(SubTask *task,
 	uint64_t span_id = SRPCGlobal::get_instance()->get_random();
 	std::string span_id_buf(SRPC_SPANID_SIZE + 1, 0);
 
-	rpc_fill_8_bytes(span_id_buf.c_str(), span_id);
+	memcpy((char *)span_id_buf.c_str(), &span_id, SRPC_SPANID_SIZE);
 	module_data[SRPC_SPAN_ID] = std::move(span_id_buf);
 
 	module_data[SRPC_START_TIMESTAMP] = std::to_string(GET_CURRENT_MS());

--- a/src/module/rpc_module_span.h
+++ b/src/module/rpc_module_span.h
@@ -67,9 +67,19 @@ static inline uint64_t htonll(uint64_t x)
 	return ((uint64_t)htonl(x & 0xFFFFFFFF) << 32) + htonl(x >> 32);
 }
 
+static inline uint64_t ntohll(uint64_t x)
+{
+	return ((uint64_t)ntohl(x & 0xFFFFFFFF) << 32) + ntohl(x >> 32);
+}
+
 #elif __BYTE_ORDER == __BIG_ENDIAN
 
 static inline uint64_t htonll(uint64_t x)
+{
+	return x;
+}
+
+static inline uint64_t ntohll(uint64_t x)
 {
 	return x;
 }

--- a/src/rpc_basic.h
+++ b/src/rpc_basic.h
@@ -34,6 +34,8 @@ static constexpr unsigned short	SRPC_SSL_DEFAULT_PORT	= 6462;
 static constexpr int			SRPC_COMPRESS_TYPE_MAX	= 10;
 static constexpr size_t			RPC_BODY_SIZE_LIMIT		= 2LL * 1024 * 1024 * 1024;
 static constexpr int			SRPC_MODULE_MAX			= 5;
+static constexpr size_t			SRPC_SPANID_SIZE		= 8;
+static constexpr size_t			SRPC_TRACEID_SIZE		= 16;
 
 using ProtobufIDLMessage = google::protobuf::Message;
 


### PR DESCRIPTION
now `RPCSpanDefault` can print the same trace_id and span_id as `RPCSpanOpenTelemetry`:

message shown on jaeger: 
```sh
{
"timestamp":1641214491653,
"traceID":"0035bb73df98f0000035bb73df98f002",
"spanID":"0035bb73e32ac000",
"parentSpanID":"0035bb73e1da4000",
"spanName":"Echo",
"spanKind":"SPAN_KIND_SERVER",
"tags.peer.service":"Example",
"ptags.ingestion.time":"1641214491813224138",
"ptags.tps.tenant.id":"default",
"duration":1000,
"statusCode":0
}
```

message print local:
```
[SPAN_LOG]
trace_id: 0035bb73df98f0000035bb73df98f002
span_id: 0035bb73e32ac000
service: Example
method: Echo
start_time: 1641214491653
parent_span_id: 0035bb73e1da4000
finish_time: 1641214491654
duration: 1
remote_ip: 127.0.0.1
port: 64352
state: 1
error: 0
[ANNOTATION]
trace_id: 0035bb73df98f0000035bb73df98f002
span_id: 0035bb73e32ac000
timestamp: 1641214491654
{"event":"info",message":"rpc server echo() end()"}
```