### PR TITLE
support ctx->set_http_code() in process() and adjust some codes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ rules_proto_toolchains()
 
 git_repository(
     name = "workflow",
-    commit = "6004c654b68be642d9817e7c3a9befcfad86f065",
+    commit = "567c01be3b908ec2f847bbe0f3e1dd1c928d8617",
     remote = "https://github.com/sogou/workflow.git")
 
 new_git_repository(

--- a/src/message/rpc_message.h
+++ b/src/message/rpc_message.h
@@ -57,6 +57,15 @@ public:
 
 	virtual void set_status_code(int code) = 0;
 	virtual void set_error(int error) = 0;
+
+	void set_http_code(int code) { this->http_code = code; }
+	int get_http_code() const { return this->http_code; }
+
+public:
+	RPCResponse() { this->http_code = 0; }
+
+private:
+	int http_code;
 };
 
 class RPCMessage

--- a/src/message/rpc_message_thrift.cc
+++ b/src/message/rpc_message_thrift.cc
@@ -242,10 +242,16 @@ bool ThriftHttpResponse::serialize_meta()
 		return false;
 
 	int rpc_status_code = this->get_status_code();
+	int http_status_code = this->get_http_code();
 
 	set_http_version("HTTP/1.1");
 	if (rpc_status_code == RPCStatusOK)
-		protocol::HttpUtil::set_response_status(this, HttpStatusOK);
+	{
+		if (http_status_code)
+			protocol::HttpUtil::set_response_status(this, http_status_code);
+		else
+			protocol::HttpUtil::set_response_status(this, HttpStatusOK);
+	}
 	else if (rpc_status_code == RPCStatusServiceNotFound
 			|| rpc_status_code == RPCStatusMethodNotFound
 			|| rpc_status_code == RPCStatusMetaError

--- a/src/rpc_context.h
+++ b/src/rpc_context.h
@@ -71,6 +71,7 @@ public:
 	virtual void set_reply_callback(std::function<void (RPCContext *ctx)> cb) = 0;
 	virtual void set_send_timeout(int timeout) = 0;
 	virtual void set_keep_alive(int timeout) = 0;
+	virtual void set_http_code(int code) = 0;
 	virtual void log(const RPCLogVector& fields) = 0;
 	virtual void baggage(const std::string& key, const std::string& value) = 0;
 	//virtual void noreply();

--- a/src/rpc_context.inl
+++ b/src/rpc_context.inl
@@ -164,6 +164,12 @@ public:
 		}
 	}
 
+	void set_http_code(int code) override
+	{
+		if (this->is_server_task())
+			task_->get_resp()->set_http_code(code);
+	}
+
 	void log(const RPCLogVector& fields) override { }
 
 	void baggage(const std::string& key, const std::string& value) override { }


### PR DESCRIPTION
### Usage:
~~~cpp
class ExampleServiceImpl : public Example::Service                                 
{                                                                                  
public:                                                                            
    void Echo(EchoRequest *req, EchoResponse *resp, RPCContext *ctx) override   
    {                                                                              
        if (req->name() != "workflow")
            ctx->set_http_code(404);
        else
            resp->set_message("Hi back"); 
    }                                                                              
};
~~~

### CURL command:
~~~sh
curl -i 127.0.0.1:1412/Example/Echo -H 'Content-Type: application/json' -d '{message:"from curl",name:"CURL"}'
~~~
### Result:
~~~sh
HTTP/1.1 404 Not Found
SRPC-Status: 1
SRPC-Error: 0
Content-Type: application/json
Content-Encoding: identity
Content-Length: 21
Connection: Keep-Alive
~~~
P. S. We can still distinguish the framework Status-OK with `SRPC-Status: 1`.