### PR TITLE
support transport baggage info in SRPC HTTP header

### DIFF
--- a/src/message/rpc_message_trpc.cc
+++ b/src/message/rpc_message_trpc.cc
@@ -1242,13 +1242,21 @@ static void __get_meta_module_data(RPCModuleData& data,
 	{
 		if (!strcasecmp(name.c_str(), "Trace-Id"))
 		{
-			data["trace_id"] = value; // TODO
+			std::string trace_id_buf(SRPC_TRACEID_SIZE + 1, 0);
+			char *ptr = (char *)trace_id_buf.c_str();
+
+			TRACE_ID_HEX_TO_BUF((char *)value.c_str(), &ptr);
+			data["trace_id"] = std::move(trace_id_buf);
 			continue;
 		}
 
 		if (!strcasecmp(name.c_str(), "Span-Id"))
 		{
-			data["parent_span_id"] = value; // TODO
+			std::string span_id_buf(SRPC_SPANID_SIZE + 1, 0);
+			char *ptr = (char *)span_id_buf.c_str();
+
+			SPAN_ID_HEX_TO_BUF((char *)value.c_str(), &ptr);
+			data["span_id"] = std::move(span_id_buf);
 			continue;
 		}
 

--- a/src/message/rpc_meta.proto
+++ b/src/message/rpc_meta.proto
@@ -12,6 +12,12 @@ message RPCResponseMeta {
 	optional int32 error = 2 [default = 0];
 };
 
+message KeyValue
+{
+	required string key = 1;
+	required bytes value = 2;
+};
+
 message RPCMeta {
 	optional RPCRequestMeta request = 1;
 	optional RPCResponseMeta response = 2;
@@ -21,4 +27,5 @@ message RPCMeta {
 	optional int32 compressed_size = 6;
 	optional int32 data_type = 7;
 	optional Span span = 8;
+	repeated KeyValue baggage = 9;
 };

--- a/src/message/rpc_span.proto
+++ b/src/message/rpc_span.proto
@@ -1,8 +1,15 @@
 syntax="proto2";
 
+message KeyValue
+{
+	required string key = 1;
+	required bytes value = 2;
+};
+
 message Span {
 	required bytes trace_id = 1;
 	required bytes span_id = 2;
 	optional bytes parent_span_id = 3;
+	repeated KeyValue baggage = 4;
 };
 

--- a/src/message/rpc_span.proto
+++ b/src/message/rpc_span.proto
@@ -1,15 +1,7 @@
 syntax="proto2";
 
-message KeyValue
-{
-	required string key = 1;
-	required bytes value = 2;
-};
-
 message Span {
 	required bytes trace_id = 1;
 	required bytes span_id = 2;
 	optional bytes parent_span_id = 3;
-	repeated KeyValue baggage = 4;
 };
-

--- a/src/module/rpc_module_span.h
+++ b/src/module/rpc_module_span.h
@@ -58,28 +58,6 @@ const char *const SRPC_SAMPLING_PRIO	= "sampling.priority";
 const char *const SRPC_DATA_TYPE		= "data.type";
 const char *const SRPC_COMPRESS_TYPE	= "compress.type";
 
-template<class RPCREQ, class RPCRESP>
-class RPCSpanContext : public RPCContextImpl<RPCREQ, RPCRESP>
-{
-public:
-	void log(const RPCLogVector& fields) override
-	{
-		auto *task = static_cast<RPCServerTask<RPCREQ, RPCRESP> *>(this->task_);
-		task->log(fields);
-	}
-
-	void baggage(const std::string& key, const std::string& value) override
-	{
-		auto *task = static_cast<RPCServerTask<RPCREQ, RPCRESP> *>(this->task_);
-		task->baggage(key, value);
-	}
-
-	RPCSpanContext(RPCServerTask<RPCREQ, RPCRESP> *task) :
-		RPCContextImpl<RPCREQ, RPCRESP>(task)
-	{
-	}
-};
-
 template<class RPCTYPE>
 class RPCSpanModule : public RPCModule
 {
@@ -88,8 +66,6 @@ public:
 									  typename RPCTYPE::RESP>;
 	using SERVER_TASK = RPCServerTask<typename RPCTYPE::REQ,
 									  typename RPCTYPE::RESP>;
-	using SPAN_CONTEXT = RPCSpanContext<typename RPCTYPE::REQ,
-										typename RPCTYPE::RESP>;
 
 	bool client_begin(SubTask *task, const RPCModuleData& data) override;
 	bool client_end(SubTask *task, RPCModuleData& data) override;
@@ -275,10 +251,6 @@ bool RPCSpanModule<RPCTYPE>::server_begin(SubTask *task,
 		module_data[SRPC_REMOTE_IP] = std::move(ip);
 		module_data[SRPC_REMOTE_PORT] = std::to_string(port);
 	}
-
-	SPAN_CONTEXT *span_ctx = new SPAN_CONTEXT(server_task);
-	delete server_task->worker.ctx;
-	server_task->worker.ctx = span_ctx;
 
 	return true;
 }

--- a/src/module/rpc_span_policies.cc
+++ b/src/module/rpc_span_policies.cc
@@ -72,24 +72,11 @@ static size_t rpc_span_log_format(RPCModuleData& data, char *str, size_t len)
 	char trace_id_buf[SRPC_TRACEID_SIZE * 2 + 1];
 	char span_id_buf[SRPC_SPANID_SIZE * 2 + 1];
 
-	uint64_t trace_id_high;
-	uint64_t trace_id_low;
-	uint64_t span_id;
+	char *ptr = trace_id_buf;
+	TRACE_ID_BUF_TO_HEX(data[SRPC_TRACE_ID].c_str(), &ptr);
 
-	memcpy(&trace_id_high, data[SRPC_TRACE_ID].c_str(), 8);
-	memcpy(&trace_id_low, data[SRPC_TRACE_ID].c_str() + 8, 8);
-	trace_id_high = ntohll(trace_id_high);
-	trace_id_low = ntohll(trace_id_low);
-
-	snprintf(trace_id_buf, SRPC_TRACEID_SIZE + 1,
-			 "%016llx", (unsigned long long)trace_id_high);
-	snprintf(trace_id_buf + SRPC_TRACEID_SIZE, SRPC_TRACEID_SIZE + 1,
-			 "%016llx", (unsigned long long)trace_id_low);
-
-	memcpy(&span_id, data[SRPC_SPAN_ID].c_str(), 8);
-	span_id = ntohll(span_id);
-	snprintf(span_id_buf, SRPC_SPANID_SIZE * 2 + 1,
-			 "%016llx", (unsigned long long)span_id);
+	ptr = span_id_buf;
+	SPAN_ID_BUF_TO_HEX(data[SRPC_SPAN_ID].c_str(), &ptr);
 
 	size_t ret = snprintf(str, len, "trace_id: %s span_id: %s service: %s"
 									" method: %s start_time: %s",

--- a/src/rpc_basic.h
+++ b/src/rpc_basic.h
@@ -42,7 +42,7 @@ static constexpr size_t			RPC_BODY_SIZE_LIMIT		= 2LL * 1024 * 1024 * 1024;
 static constexpr int			SRPC_MODULE_MAX			= 5;
 static constexpr size_t			SRPC_SPANID_SIZE		= 8;
 static constexpr size_t			SRPC_TRACEID_SIZE		= 16;
-static constexpr const char	   *SRPC_BAGGAGE_PREFIX		= "baggage-";
+static constexpr const char	   *SRPC_BAGGAGE_PREFIX		= "user-";
 static constexpr size_t			SRPC_BAGGAGE_PREFIX_LEN	= 8;
 
 #ifndef htonll
@@ -180,6 +180,28 @@ static inline void SPAN_ID_BUF_TO_HEX(const char *in, char **hex_out)
 
 	snprintf(*hex_out, SRPC_SPANID_SIZE * 2 + 1,
 			 "%016llx", (unsigned long long)span_id);
+}
+
+// here hex_in is not 'const' char *
+static inline void TRACE_ID_HEX_TO_BUF(char *hex_in, char **out)
+{
+	uint64_t trace_id_low = strtoull(hex_in + 16, NULL, 16);
+	hex_in[16] = '\0';
+	uint64_t trace_id_high = strtoull(hex_in, NULL, 16);
+
+	trace_id_high = htonll(trace_id_high);
+	trace_id_low = htonll(trace_id_low);
+
+	memcpy(*out, &trace_id_high, SRPC_TRACEID_SIZE / 2);
+	memcpy((*out) + SRPC_TRACEID_SIZE / 2, &trace_id_low, SRPC_TRACEID_SIZE / 2);
+}
+
+static inline void SPAN_ID_HEX_TO_BUF(char *hex_in, char **out)
+{
+	uint64_t span_id = strtoull(hex_in, NULL, 16);
+
+	span_id = htonll(span_id);
+	memcpy(*out, &span_id, SRPC_SPANID_SIZE);
 }
 
 } // end namespace srpc

--- a/src/rpc_basic.h
+++ b/src/rpc_basic.h
@@ -42,6 +42,8 @@ static constexpr size_t			RPC_BODY_SIZE_LIMIT		= 2LL * 1024 * 1024 * 1024;
 static constexpr int			SRPC_MODULE_MAX			= 5;
 static constexpr size_t			SRPC_SPANID_SIZE		= 8;
 static constexpr size_t			SRPC_TRACEID_SIZE		= 16;
+static constexpr const char	   *SRPC_BAGGAGE_PREFIX		= "baggage-";
+static constexpr size_t			SRPC_BAGGAGE_PREFIX_LEN	= 8;
 
 #ifndef htonll
 
@@ -81,18 +83,6 @@ static inline uint64_t ntohll(uint64_t x)
 #define SRPC_JSON_OPTION_PRINT_PRIMITIVE	(1<<6)
 
 using ProtobufIDLMessage = google::protobuf::Message;
-
-static inline long long GET_CURRENT_MS()
-{
-	return std::chrono::duration_cast<std::chrono::milliseconds>(
-			std::chrono::system_clock::now().time_since_epoch()).count();
-};
-
-static inline long long GET_CURRENT_MS_STEADY()
-{
-	return std::chrono::duration_cast<std::chrono::milliseconds>(
-			std::chrono::steady_clock::now().time_since_epoch()).count();
-}
 
 enum RPCDataType
 {
@@ -152,6 +142,45 @@ enum RPCModuleType
 	RPCModuleMonitor	=	1,
 	RPCModuleEmpty		=	2
 };
+
+static inline long long GET_CURRENT_MS()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::system_clock::now().time_since_epoch()).count();
+};
+
+static inline long long GET_CURRENT_MS_STEADY()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+static inline void TRACE_ID_BUF_TO_HEX(const char *in, char **hex_out)
+{
+	uint64_t trace_id_high;
+	uint64_t trace_id_low;
+
+	memcpy(&trace_id_high, in, 8);
+	memcpy(&trace_id_low, in + 8, 8);
+	trace_id_high = ntohll(trace_id_high);
+	trace_id_low = ntohll(trace_id_low);
+
+	snprintf(*hex_out, SRPC_TRACEID_SIZE + 1,
+			 "%016llx", (unsigned long long)trace_id_high);
+	snprintf(*hex_out + SRPC_TRACEID_SIZE, SRPC_TRACEID_SIZE + 1,
+			 "%016llx", (unsigned long long)trace_id_low);
+}
+
+static inline void SPAN_ID_BUF_TO_HEX(const char *in, char **hex_out)
+{
+	uint64_t span_id;
+
+	memcpy(&span_id, in, 8);
+	span_id = ntohll(span_id);
+
+	snprintf(*hex_out, SRPC_SPANID_SIZE * 2 + 1,
+			 "%016llx", (unsigned long long)span_id);
+}
 
 } // end namespace srpc
 

--- a/src/rpc_context.h
+++ b/src/rpc_context.h
@@ -73,7 +73,8 @@ public:
 	virtual void set_keep_alive(int timeout) = 0;
 	virtual void set_http_code(int code) = 0;
 	virtual void log(const RPCLogVector& fields) = 0;
-	virtual void baggage(const std::string& key, const std::string& value) = 0;
+	virtual void set_baggage(const std::string& key, const std::string& value) = 0;
+	virtual std::string get_baggage(const std::string& key) const = 0;
 	//virtual void noreply();
 	//virtual WFConnection *get_connection();
 
@@ -101,6 +102,12 @@ public:
 public:
 	virtual ~RPCContext() { }
 };
+
+template<class RPCREQ, class RPCRESP>
+class RPCClientTask;
+
+template<class RPCREQ, class RPCRESP>
+class RPCServerTask;
 
 } // namespace srpc
 

--- a/src/rpc_context.inl
+++ b/src/rpc_context.inl
@@ -170,9 +170,37 @@ public:
 			task_->get_resp()->set_http_code(code);
 	}
 
-	void log(const RPCLogVector& fields) override { }
+	void log(const RPCLogVector& fields) override
+	{
+		if (this->is_server_task())
+		{
+			auto *task = (RPCServerTask<RPCREQ, RPCRESP> *)this->task_;
+			task->log(fields);
+		}
+	}
 
-	void baggage(const std::string& key, const std::string& value) override { }
+	void set_baggage(const std::string& key, const std::string& value) override
+	{
+		if (this->is_server_task())
+		{
+			auto *task = (RPCServerTask<RPCREQ, RPCRESP> *)this->task_;
+			task->set_baggage(key, value);
+		}
+	}
+
+	std::string get_baggage(const std::string& key) const
+	{
+		if (this->is_server_task())
+		{
+			auto *task = (RPCServerTask<RPCREQ, RPCRESP> *)this->task_;
+			return task->get_baggage(key);
+		}
+		else
+		{
+			auto *task = (RPCClientTask<RPCREQ, RPCRESP> *)this->task_;
+			return task->get_baggage(key);
+		}
+	}
 
 	void set_json_add_whitespace(bool on) override
 	{


### PR DESCRIPTION
### Description:
It's reasonable to transport baggage info and other info through Http header. In the past, SRPC Http only transported trace-id and span-id. Now it supports all the baggage info in **SRPCHttp** / **SRPCStd** / **TrpcHttp** / **TrpcStd**.

`baggage` is implemented according to the semantics of [specification in open-telemetry: baggage-signal](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#baggage-signal).

As a client, please use the api **create_XXX_task**() and use `set_baggage()`/`get_baggage()` on task.
As a server, please use the `set_baggage()`/`get_baggage()` on **RPCContext** in **process()**.

### Client Example:
```cpp
int main()                                                                      
{                                                                               
    Example::SRPCHttpClient client("127.0.0.1", 1412);                          
                                                                                
    EchoRequest req;                                                            
    req.set_message("Hello, sogou rpc!");                                       
    req.set_name("1412");                                                       
                           
    auto *rpc_task = client.create_Echo_task([](EchoResponse *resp, RPCContext *ctx) {
        /* callback */ 
    }); 
    rpc_task->serialize_input(&req);                                            
    rpc_task->set_baggage("baggage_key", "baggage_value"); // baggage can be transported
    rpc_task->log({{"event", "info"}, {"message", "rpc client task log."}}); // log will not be transported
    ...
```
### Server get :
```sh
POST HTTP/1.1 /Example/Echo
Host: 127.0.0.1:1412
baggage_key: baggage_value
Content-Type: application/json
Content-Encoding: identity
Content-Length: 45
Connection: Keep-Alive

{"message":"Hello, sogou rpc!","name":"1412"}
```

