### PR TITLE
support set/get_http_header() and update some other codes

### DIFF
--- a/src/message/rpc_message.h
+++ b/src/message/rpc_message.h
@@ -58,14 +58,7 @@ public:
 	virtual void set_status_code(int code) = 0;
 	virtual void set_error(int error) = 0;
 
-	void set_http_code(int code) { this->http_code = code; }
-	int get_http_code() const { return this->http_code; }
-
-public:
-	RPCResponse() { this->http_code = 0; }
-
-private:
-	int http_code;
+	virtual bool set_http_code(const char *code) { return false; }
 };
 
 class RPCMessage

--- a/src/message/rpc_message.h
+++ b/src/message/rpc_message.h
@@ -76,14 +76,17 @@ public:
 	virtual bool get_meta_module_data(RPCModuleData& data) const = 0;
 	virtual bool set_meta_module_data(const RPCModuleData& data) = 0;
 
-	void set_json_add_whitespace(bool on);
-	bool get_json_add_whitespace() const;
-	void set_json_enums_as_ints(bool on);
-	bool get_json_enums_as_ints() const;
-	void set_json_preserve_names(bool on);
-	bool get_json_preserve_names() const;
-	void set_json_print_primitive(bool on);
-	bool get_json_print_primitive() const;
+	virtual bool set_http_header(const char *name, const char *value) { return false; }
+	virtual std::string get_http_header(std::string& key) const { return ""; }
+
+	virtual void set_json_add_whitespace(bool on);
+	virtual bool get_json_add_whitespace() const;
+	virtual void set_json_enums_as_ints(bool on);
+	virtual bool get_json_enums_as_ints() const;
+	virtual void set_json_preserve_names(bool on);
+	virtual bool get_json_preserve_names() const;
+	virtual void set_json_print_primitive(bool on);
+	virtual bool get_json_print_primitive() const;
 
 public:
 	//pb
@@ -115,7 +118,6 @@ public:
 protected:
 	uint32_t flags;
 };
-
 
 // implementation
 

--- a/src/message/rpc_message.h
+++ b/src/message/rpc_message.h
@@ -58,7 +58,7 @@ public:
 	virtual void set_status_code(int code) = 0;
 	virtual void set_error(int error) = 0;
 
-	virtual bool set_http_code(const char *code) { return false; }
+	virtual bool set_http_code(int code) { return false; }
 };
 
 class RPCMessage
@@ -76,8 +76,16 @@ public:
 	virtual bool get_meta_module_data(RPCModuleData& data) const = 0;
 	virtual bool set_meta_module_data(const RPCModuleData& data) = 0;
 
-	virtual bool set_http_header(const char *name, const char *value) { return false; }
-	virtual std::string get_http_header(std::string& key) const { return ""; }
+	virtual bool set_http_header(const std::string& name,
+								 const std::string& value)
+	{
+		return false;
+	}
+	virtual bool get_http_header(const std::string& name,
+								 std::string& value) const
+	{
+		return false;
+	}
 
 	virtual void set_json_add_whitespace(bool on);
 	virtual bool get_json_add_whitespace() const;

--- a/src/message/rpc_message_srpc.cc
+++ b/src/message/rpc_message_srpc.cc
@@ -990,18 +990,17 @@ static bool __get_meta_module_data(RPCModuleData& data,
 	{
 		if (strcasecmp(name.c_str(), "Trace-Id") == 0)
 		{
-			char trace_id_buf[SRPC_TRACEID_SIZE * 2 + 1];
-
+			uint64_t trace_id_buf[2];
+			char *ptr = (char *)trace_id_buf;
 			TRACE_ID_HEX_TO_BUF((char *)value.c_str(), trace_id_buf);
-			data["trace_id"] = trace_id_buf;
+			data["trace_id"] = std::string(ptr, SRPC_TRACEID_SIZE);
 			flag |= 1;
 		}
 		else if (strcasecmp(name.c_str(), "Span-Id") == 0)
 		{
-			char span_id_buf[SRPC_SPANID_SIZE * 2 + 1];
-
-			SPAN_ID_HEX_TO_BUF((char *)value.c_str(), span_id_buf);
-			data["span_id"] = span_id_buf;
+			uint64_t span_id = strtoull((char *)value.c_str(), NULL, 16);
+			span_id = htonll(span_id);
+			data["span_id"] = std::string((char *)&span_id, SRPC_SPANID_SIZE);
 			flag |= (1 << 1);
 		}
 	}

--- a/src/message/rpc_message_srpc.cc
+++ b/src/message/rpc_message_srpc.cc
@@ -873,13 +873,13 @@ bool SRPCHttpResponse::serialize_meta()
 	int data_type = meta->data_type();
 	int compress_type = meta->compress_type();
 	int rpc_status_code = this->get_status_code();
-	int http_status_code = this->get_http_code();
+	const char *http_status_code = this->protocol::HttpResponse::get_status_code();
 
 	set_http_version("HTTP/1.1");
 	if (rpc_status_code == RPCStatusOK)
 	{
 		if (http_status_code)
-			protocol::HttpUtil::set_response_status(this, http_status_code);
+			protocol::HttpUtil::set_response_status(this, atoi(http_status_code));
 		else
 			protocol::HttpUtil::set_response_status(this, HttpStatusOK);
 	}

--- a/src/message/rpc_message_srpc.cc
+++ b/src/message/rpc_message_srpc.cc
@@ -988,7 +988,8 @@ static bool __get_meta_module_data(RPCModuleData& data,
 
 	while (cursor.next(name, value) && flag != 3)
 	{
-		if (strcasecmp(name.c_str(), "Trace-Id") == 0)
+		if (strcasecmp(name.c_str(), "Trace-Id") == 0 &&
+			value.length() == SRPC_TRACEID_SIZE * 2)
 		{
 			uint64_t trace_id_buf[2];
 			char *ptr = (char *)trace_id_buf;
@@ -996,7 +997,8 @@ static bool __get_meta_module_data(RPCModuleData& data,
 			data["trace_id"] = std::string(ptr, SRPC_TRACEID_SIZE);
 			flag |= 1;
 		}
-		else if (strcasecmp(name.c_str(), "Span-Id") == 0)
+		else if (strcasecmp(name.c_str(), "Span-Id") == 0 &&
+				 value.length() == SRPC_SPANID_SIZE * 2)
 		{
 			uint64_t span_id = strtoull((char *)value.c_str(), NULL, 16);
 			span_id = htonll(span_id);

--- a/src/message/rpc_message_srpc.cc
+++ b/src/message/rpc_message_srpc.cc
@@ -1029,5 +1029,42 @@ bool SRPCHttpResponse::get_meta_module_data(RPCModuleData& data) const
 	return found;
 }
 
+static std::string __get_http_header(std::string& key,
+									 const protocol::HttpMessage *http_msg)
+{
+	std::string name;
+	std::string value;
+
+	protocol::HttpHeaderCursor cursor(http_msg);
+
+	while (cursor.next(name, value))
+	{
+		if (key == name)
+			break;
+	}
+
+	return std::move(value);
+}
+
+bool SRPCHttpRequest::set_http_header(const char *name, const char *value)
+{
+	return this->protocol::HttpMessage::set_header_pair(name, value);
+}
+
+std::string SRPCHttpRequest::get_http_header(std::string& key) const
+{
+	return __get_http_header(key, this);
+}
+
+bool SRPCHttpResponse::set_http_header(const char *name, const char *value)
+{
+	return this->protocol::HttpMessage::set_header_pair(name, value);
+}
+
+std::string SRPCHttpResponse::get_http_header(std::string& key) const
+{
+	return __get_http_header(key, this);
+}
+
 } // namespace srpc
 

--- a/src/message/rpc_message_srpc.h
+++ b/src/message/rpc_message_srpc.h
@@ -262,8 +262,8 @@ public:
 	bool set_meta_module_data(const RPCModuleData& data) override;
 	bool get_meta_module_data(RPCModuleData& data) const override;
 
-	bool set_http_header(const char *name, const char *value) override;
-	std::string get_http_header(std::string& key) const override;
+	bool set_http_header(const std::string& name, const std::string& value) override;
+	bool get_http_header(const std::string& name, std::string& value) const override;
 
 public:
 	SRPCHttpRequest() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
@@ -301,16 +301,16 @@ public:
 		return this->SRPCResponse::set_error(error);
 	}
 
-	bool set_http_code(const char *code) override
+	bool set_http_code(int code) override
 	{
-		return this->protocol::HttpResponse::set_status_code(code);
+		return this->protocol::HttpResponse::set_status_code(std::to_string(code));
 	}
 
 	bool set_meta_module_data(const RPCModuleData& data) override;
 	bool get_meta_module_data(RPCModuleData& data) const override;
 
-	bool set_http_header(const char *name, const char *value) override;
-	std::string get_http_header(std::string& key) const override;
+	bool set_http_header(const std::string& name, const std::string& value) override;
+	bool get_http_header(const std::string& name, std::string& value) const override;
 
 public:
 	SRPCHttpResponse() { this->size_limit = RPC_BODY_SIZE_LIMIT; }

--- a/src/message/rpc_message_srpc.h
+++ b/src/message/rpc_message_srpc.h
@@ -298,6 +298,11 @@ public:
 		return this->SRPCResponse::set_error(error);
 	}
 
+	bool set_http_code(const char *code) override
+	{
+		return this->protocol::HttpResponse::set_status_code(code);
+	}
+
 	bool set_meta_module_data(const RPCModuleData& data) override;
 	bool get_meta_module_data(RPCModuleData& data) const override;
 

--- a/src/message/rpc_message_srpc.h
+++ b/src/message/rpc_message_srpc.h
@@ -262,6 +262,9 @@ public:
 	bool set_meta_module_data(const RPCModuleData& data) override;
 	bool get_meta_module_data(RPCModuleData& data) const override;
 
+	bool set_http_header(const char *name, const char *value) override;
+	std::string get_http_header(std::string& key) const override;
+
 public:
 	SRPCHttpRequest() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
@@ -305,6 +308,9 @@ public:
 
 	bool set_meta_module_data(const RPCModuleData& data) override;
 	bool get_meta_module_data(RPCModuleData& data) const override;
+
+	bool set_http_header(const char *name, const char *value) override;
+	std::string get_http_header(std::string& key) const override;
 
 public:
 	SRPCHttpResponse() { this->size_limit = RPC_BODY_SIZE_LIMIT; }

--- a/src/message/rpc_message_thrift.cc
+++ b/src/message/rpc_message_thrift.cc
@@ -295,5 +295,42 @@ bool ThriftHttpResponse::deserialize_meta()
 	return this->ThriftResponse::deserialize_meta();
 }
 
+static std::string __get_http_header(std::string& key,
+									 const protocol::HttpMessage *http_msg)
+{
+	std::string name;
+	std::string value;
+
+	protocol::HttpHeaderCursor cursor(http_msg);
+
+	while (cursor.next(name, value))
+	{
+		if (key == name)
+			break;
+	}
+
+	return std::move(value);
 }
+
+bool ThriftHttpRequest::set_http_header(const char *name, const char *value)
+{
+	return this->protocol::HttpMessage::set_header_pair(name, value);
+}
+
+std::string ThriftHttpRequest::get_http_header(std::string& key) const
+{
+	return __get_http_header(key, this);
+}
+
+bool ThriftHttpResponse::set_http_header(const char *name, const char *value)
+{
+	return this->protocol::HttpMessage::set_header_pair(name, value);
+}
+
+std::string ThriftHttpResponse::get_http_header(std::string& key) const
+{
+	return __get_http_header(key, this);
+}
+
+} // namespace srpc
 

--- a/src/message/rpc_message_thrift.cc
+++ b/src/message/rpc_message_thrift.cc
@@ -242,13 +242,13 @@ bool ThriftHttpResponse::serialize_meta()
 		return false;
 
 	int rpc_status_code = this->get_status_code();
-	int http_status_code = this->get_http_code();
+	const char *http_status_code = this->protocol::HttpResponse::get_status_code();
 
 	set_http_version("HTTP/1.1");
 	if (rpc_status_code == RPCStatusOK)
 	{
 		if (http_status_code)
-			protocol::HttpUtil::set_response_status(this, http_status_code);
+			protocol::HttpUtil::set_response_status(this, atoi(http_status_code));
 		else
 			protocol::HttpUtil::set_response_status(this, HttpStatusOK);
 	}

--- a/src/message/rpc_message_thrift.h
+++ b/src/message/rpc_message_thrift.h
@@ -314,6 +314,9 @@ public:
 		return this->ThriftMessage::get_meta_module_data(data);
 	}
 
+	bool set_http_header(const char *name, const char *value) override;
+	std::string get_http_header(std::string& key) const override;
+
 public:
 	ThriftHttpRequest() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
@@ -364,6 +367,9 @@ public:
 	{
 		return this->ThriftMessage::get_meta_module_data(data);
 	}
+
+	bool set_http_header(const char *name, const char *value) override;
+	std::string get_http_header(std::string& key) const override;
 
 public:
 	ThriftHttpResponse() { this->size_limit = RPC_BODY_SIZE_LIMIT; }

--- a/src/message/rpc_message_thrift.h
+++ b/src/message/rpc_message_thrift.h
@@ -41,7 +41,8 @@ public:
 	ThriftException()
 	{
 		this->elements = ThriftElementsImpl<ThriftException>::get_elements_instance();
-		this->descriptor = ThriftDescriptorImpl<ThriftException, TDT_STRUCT, void, void>::get_instance();
+		this->descriptor = ThriftDescriptorImpl<ThriftException, TDT_STRUCT,
+												void, void>::get_instance();
 	}
 
 	static void StaticElementsImpl(std::list<struct_element> *elements)
@@ -51,8 +52,12 @@ public:
 		using subtype_1 = ThriftDescriptorImpl<std::string, TDT_STRING, void, void>;
 		using subtype_2 = ThriftDescriptorImpl<int32_t, TDT_I32, void, void>;
 
-		elements->push_back({subtype_1::get_instance(), "message", (const char *)(&st->__isset.message) - base, (const char *)(&st->message) - base, 1});
-		elements->push_back({subtype_2::get_instance(), "type", (const char *)(&st->__isset.type) - base, (const char *)(&st->type) - base, 2});
+		elements->push_back({subtype_1::get_instance(), "message",
+							 (const char *)(&st->__isset.message) - base,
+							 (const char *)(&st->message) - base, 1});
+		elements->push_back({subtype_2::get_instance(), "type",
+							 (const char *)(&st->__isset.type) - base,
+							 (const char *)(&st->type) - base, 2});
 	}
 };
 
@@ -78,7 +83,10 @@ public:
 	void set_data_type(int type) override {}
 
 	void set_attachment_nocopy(const char *attachment, size_t len) { }
-	bool get_attachment_nocopy(const char **attachment, size_t *len) const { return false; }
+	bool get_attachment_nocopy(const char **attachment, size_t *len) const
+	{
+		return false;
+	}
 
 public:
 	int serialize(const ThriftIDLMessage *thrift_msg) override;
@@ -114,7 +122,10 @@ public:
 	const std::string& get_method_name() const { return TBuffer_.meta.method_name; }
 
 	void set_service_name(const std::string& service_name) { }
-	void set_method_name(const std::string& method_name) { TBuffer_.meta.method_name = method_name; }
+	void set_method_name(const std::string& method_name)
+	{
+		TBuffer_.meta.method_name = method_name;
+	}
 	void set_seqid(long long seqid) { TBuffer_.meta.seqid = (int)seqid; }
 };
 
@@ -144,7 +155,8 @@ protected:
 	std::string errmsg_;
 };
 
-class ThriftStdRequest : public protocol::ProtocolMessage, public RPCRequest, public ThriftRequest
+class ThriftStdRequest : public protocol::ProtocolMessage, public RPCRequest,
+						 public ThriftRequest
 {
 public:
 	int encode(struct iovec vectors[], int max) override
@@ -208,7 +220,8 @@ public:
 	ThriftStdRequest() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
 
-class ThriftStdResponse : public protocol::ProtocolMessage, public RPCResponse, public ThriftResponse
+class ThriftStdResponse : public protocol::ProtocolMessage, public RPCResponse,
+						  public ThriftResponse
 {
 public:
 	int encode(struct iovec vectors[], int max) override
@@ -272,7 +285,8 @@ public:
 	ThriftStdResponse() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
 
-class ThriftHttpRequest : public protocol::HttpRequest, public RPCRequest, public ThriftRequest
+class ThriftHttpRequest : public protocol::HttpRequest, public RPCRequest,
+						  public ThriftRequest
 {
 public:
 	bool serialize_meta() override;
@@ -314,14 +328,17 @@ public:
 		return this->ThriftMessage::get_meta_module_data(data);
 	}
 
-	bool set_http_header(const char *name, const char *value) override;
-	std::string get_http_header(std::string& key) const override;
+	bool set_http_header(const std::string& name,
+						 const std::string& value) override;
+	bool get_http_header(const std::string& name,
+						 std::string& value) const override;
 
 public:
 	ThriftHttpRequest() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
 
-class ThriftHttpResponse : public protocol::HttpResponse, public RPCResponse, public ThriftResponse
+class ThriftHttpResponse : public protocol::HttpResponse, public RPCResponse,
+						   public ThriftResponse
 {
 public:
 	bool serialize_meta() override;
@@ -353,9 +370,9 @@ public:
 		return this->ThriftResponse::set_error(error);
 	}
 
-	bool set_http_code(const char *code) override
+	bool set_http_code(int code) override
 	{
-		return this->protocol::HttpResponse::set_status_code(code);
+		return this->protocol::HttpResponse::set_status_code(std::to_string(code));
 	}
 
 	bool set_meta_module_data(const RPCModuleData& data) override
@@ -368,8 +385,10 @@ public:
 		return this->ThriftMessage::get_meta_module_data(data);
 	}
 
-	bool set_http_header(const char *name, const char *value) override;
-	std::string get_http_header(std::string& key) const override;
+	bool set_http_header(const std::string& name,
+						 const std::string& value) override;
+	bool get_http_header(const std::string& name,
+						 std::string& value) const override;
 
 public:
 	ThriftHttpResponse() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
@@ -384,8 +403,9 @@ inline int ThriftMessage::serialize(const ThriftIDLMessage *thrift_msg)
 	{
 		if (!thrift_msg->descriptor->writer(thrift_msg, &TBuffer_))
 		{
-			return TBuffer_.meta.message_type == TMT_CALL ? RPCStatusReqSerializeError
-														  : RPCStatusRespSerializeError;
+			return TBuffer_.meta.message_type == TMT_CALL ?
+												 RPCStatusReqSerializeError :
+												 RPCStatusRespSerializeError;
 		}
 	}
 
@@ -398,15 +418,17 @@ inline int ThriftMessage::deserialize(ThriftIDLMessage *thrift_msg)
 	{
 		if (!thrift_msg->descriptor->reader(&TBuffer_, thrift_msg))
 		{
-			return TBuffer_.meta.message_type == TMT_CALL ? RPCStatusReqDeserializeError
-														  : RPCStatusRespDeserializeError;
+			return TBuffer_.meta.message_type == TMT_CALL ?
+												 RPCStatusReqDeserializeError :
+												 RPCStatusRespDeserializeError;
 		}
 	}
 
 	return RPCStatusOK;
 }
 
-inline int ThriftMessage::encode(struct iovec vectors[], int max, size_t size_limit)
+inline int ThriftMessage::encode(struct iovec vectors[], int max,
+								 size_t size_limit)
 {
 	size_t sz = TBuffer_.meta.writebuf.size() + buf_.size();
 
@@ -432,7 +454,7 @@ inline int ThriftMessage::encode(struct iovec vectors[], int max, size_t size_li
 	return 0;
 }
 
-}
+} // namespace srpc
 
 #endif
 

--- a/src/message/rpc_message_thrift.h
+++ b/src/message/rpc_message_thrift.h
@@ -350,6 +350,11 @@ public:
 		return this->ThriftResponse::set_error(error);
 	}
 
+	bool set_http_code(const char *code) override
+	{
+		return this->protocol::HttpResponse::set_status_code(code);
+	}
+
 	bool set_meta_module_data(const RPCModuleData& data) override
 	{
 		return this->ThriftMessage::set_meta_module_data(data);

--- a/src/message/rpc_message_trpc.cc
+++ b/src/message/rpc_message_trpc.cc
@@ -1222,41 +1222,30 @@ bool TRPCHttpResponse::get_meta_module_data(RPCModuleData& data) const
 	return true;
 }
 
-static std::string __get_http_header(std::string& key,
-									 const protocol::HttpMessage *http_msg)
-{
-	std::string name;
-	std::string value;
-
-	protocol::HttpHeaderCursor cursor(http_msg);
-
-	while (cursor.next(name, value))
-	{
-		if (key == name)
-			break;
-	}
-
-	return std::move(value);
-}
-
-bool TRPCHttpRequest::set_http_header(const char *name, const char *value)
+bool TRPCHttpRequest::set_http_header(const std::string& name,
+									  const std::string& value)
 {
 	return this->protocol::HttpMessage::set_header_pair(name, value);
 }
 
-std::string TRPCHttpRequest::get_http_header(std::string& key) const
+bool TRPCHttpRequest::get_http_header(const std::string& name,
+									  std::string& value) const
 {
-	return __get_http_header(key, this);
+	protocol::HttpHeaderCursor cursor(this);
+	return cursor.find(name, value);
 }
 
-bool TRPCHttpResponse::set_http_header(const char *name, const char *value)
+bool TRPCHttpResponse::set_http_header(const std::string& name,
+									   const std::string& value)
 {
 	return this->protocol::HttpMessage::set_header_pair(name, value);
 }
 
-std::string TRPCHttpResponse::get_http_header(std::string& key) const
+bool TRPCHttpResponse::get_http_header(const std::string& name,
+									   std::string& value) const
 {
-	return __get_http_header(key, this);
+	protocol::HttpHeaderCursor cursor(this);
+	return cursor.find(name, value);
 }
 
 } // namespace srpc

--- a/src/message/rpc_message_trpc.cc
+++ b/src/message/rpc_message_trpc.cc
@@ -1056,13 +1056,13 @@ bool TRPCHttpResponse::serialize_meta()
 	int compress_type = this->get_compress_type();
 	int rpc_status_code = this->get_status_code();
 	int rpc_error = this->get_error();
-	int http_status_code = this->get_http_code();
+	const char *http_status_code = this->protocol::HttpResponse::get_status_code();
 
 	set_http_version("HTTP/1.1");
 	if (rpc_status_code == RPCStatusOK)
 	{
 		if (http_status_code)
-			protocol::HttpUtil::set_response_status(this, http_status_code);
+			protocol::HttpUtil::set_response_status(this, atoi(http_status_code));
 		else
 			protocol::HttpUtil::set_response_status(this, HttpStatusOK);
 	}

--- a/src/message/rpc_message_trpc.cc
+++ b/src/message/rpc_message_trpc.cc
@@ -1222,5 +1222,42 @@ bool TRPCHttpResponse::get_meta_module_data(RPCModuleData& data) const
 	return true;
 }
 
+static std::string __get_http_header(std::string& key,
+									 const protocol::HttpMessage *http_msg)
+{
+	std::string name;
+	std::string value;
+
+	protocol::HttpHeaderCursor cursor(http_msg);
+
+	while (cursor.next(name, value))
+	{
+		if (key == name)
+			break;
+	}
+
+	return std::move(value);
+}
+
+bool TRPCHttpRequest::set_http_header(const char *name, const char *value)
+{
+	return this->protocol::HttpMessage::set_header_pair(name, value);
+}
+
+std::string TRPCHttpRequest::get_http_header(std::string& key) const
+{
+	return __get_http_header(key, this);
+}
+
+bool TRPCHttpResponse::set_http_header(const char *name, const char *value)
+{
+	return this->protocol::HttpMessage::set_header_pair(name, value);
+}
+
+std::string TRPCHttpResponse::get_http_header(std::string& key) const
+{
+	return __get_http_header(key, this);
+}
+
 } // namespace srpc
 

--- a/src/message/rpc_message_trpc.h
+++ b/src/message/rpc_message_trpc.h
@@ -303,6 +303,9 @@ public:
 		return this->TRPCRequest::get_caller_name();
 	}
 
+	bool set_http_header(const char *name, const char *value) override;
+	std::string get_http_header(std::string& key) const override;
+
 public:
 	TRPCHttpRequest() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
@@ -346,6 +349,9 @@ public:
 
 	bool set_meta_module_data(const RPCModuleData& data) override;
 	bool get_meta_module_data(RPCModuleData& data) const override;
+
+	bool set_http_header(const char *name, const char *value) override;
+	std::string get_http_header(std::string& key) const override;
 
 public:
 	TRPCHttpResponse() { this->size_limit = RPC_BODY_SIZE_LIMIT; }

--- a/src/message/rpc_message_trpc.h
+++ b/src/message/rpc_message_trpc.h
@@ -339,6 +339,11 @@ public:
 		return this->TRPCResponse::set_error(error);
 	}
 
+	bool set_http_code(const char *code) override
+	{
+		return this->protocol::HttpResponse::set_status_code(code);
+	}
+
 	bool set_meta_module_data(const RPCModuleData& data) override;
 	bool get_meta_module_data(RPCModuleData& data) const override;
 

--- a/src/message/rpc_message_trpc.h
+++ b/src/message/rpc_message_trpc.h
@@ -41,8 +41,11 @@ public:
 	int encode(struct iovec vectors[], int max, size_t size_limit);
 	int append(const void *buf, size_t *size, size_t size_limit);
 
-	bool get_attachment_nocopy(const char **attachment, size_t *len) const { return false; }
 	void set_attachment_nocopy(const char *attachment, size_t len) { }
+	bool get_attachment_nocopy(const char **attachment, size_t *len) const
+	{
+		return false;
+	}
 
 public:
 	using RPCMessage::serialize;
@@ -135,7 +138,8 @@ protected:
 	std::string srpc_error_msg;
 };
 
-class TRPCStdRequest : public protocol::ProtocolMessage, public RPCRequest, public TRPCRequest
+class TRPCStdRequest : public protocol::ProtocolMessage, public RPCRequest,
+					   public TRPCRequest
 {
 public:
 	int encode(struct iovec vectors[], int max) override
@@ -199,7 +203,8 @@ public:
 	TRPCStdRequest() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
 
-class TRPCStdResponse : public protocol::ProtocolMessage, public RPCResponse, public TRPCResponse
+class TRPCStdResponse : public protocol::ProtocolMessage, public RPCResponse,
+						public TRPCResponse
 {
 public:
 	int encode(struct iovec vectors[], int max) override
@@ -263,7 +268,8 @@ public:
 	TRPCStdResponse() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
 
-class TRPCHttpRequest : public protocol::HttpRequest, public RPCRequest, public TRPCRequest
+class TRPCHttpRequest : public protocol::HttpRequest, public RPCRequest,
+						public TRPCRequest
 {
 public:
 	bool serialize_meta() override;
@@ -303,14 +309,17 @@ public:
 		return this->TRPCRequest::get_caller_name();
 	}
 
-	bool set_http_header(const char *name, const char *value) override;
-	std::string get_http_header(std::string& key) const override;
+	bool set_http_header(const std::string& name,
+						 const std::string& value) override;
+	bool get_http_header(const std::string& name,
+						 std::string& value) const override;
 
 public:
 	TRPCHttpRequest() { this->size_limit = RPC_BODY_SIZE_LIMIT; }
 };
 
-class TRPCHttpResponse : public protocol::HttpResponse, public RPCResponse, public TRPCResponse
+class TRPCHttpResponse : public protocol::HttpResponse, public RPCResponse,
+						 public TRPCResponse
 {
 public:
 	bool serialize_meta() override;
@@ -342,16 +351,18 @@ public:
 		return this->TRPCResponse::set_error(error);
 	}
 
-	bool set_http_code(const char *code) override
+	bool set_http_code(int code) override
 	{
-		return this->protocol::HttpResponse::set_status_code(code);
+		return this->protocol::HttpResponse::set_status_code(std::to_string(code));
 	}
 
 	bool set_meta_module_data(const RPCModuleData& data) override;
 	bool get_meta_module_data(RPCModuleData& data) const override;
 
-	bool set_http_header(const char *name, const char *value) override;
-	std::string get_http_header(std::string& key) const override;
+	bool set_http_header(const std::string& name,
+						 const std::string& value) override;
+	bool get_http_header(const std::string& name,
+						 std::string& value) const override;
 
 public:
 	TRPCHttpResponse() { this->size_limit = RPC_BODY_SIZE_LIMIT; }

--- a/src/module/rpc_span_policies.cc
+++ b/src/module/rpc_span_policies.cc
@@ -72,24 +72,11 @@ static size_t rpc_span_log_format(RPCModuleData& data, char *str, size_t len)
 	char trace_id_buf[SRPC_TRACEID_SIZE * 2 + 1];
 	char span_id_buf[SRPC_SPANID_SIZE * 2 + 1];
 
-	uint64_t trace_id_high;
-	uint64_t trace_id_low;
-	uint64_t span_id;
+	char *ptr = trace_id_buf;
+	TRACE_ID_BUF_TO_HEX(data[SRPC_TRACE_ID].c_str(), &ptr);
 
-	memcpy(&trace_id_high, data[SRPC_TRACE_ID].c_str(), 8);
-	memcpy(&trace_id_low, data[SRPC_TRACE_ID].c_str() + 8, 8);
-	trace_id_high = ntohll(trace_id_high);
-	trace_id_low = ntohll(trace_id_low);
-
-	snprintf(trace_id_buf, SRPC_TRACEID_SIZE + 1,
-			 "%016llx", (unsigned long long)trace_id_high);
-	snprintf(trace_id_buf + SRPC_TRACEID_SIZE, SRPC_TRACEID_SIZE + 1,
-			 "%016llx", (unsigned long long)trace_id_low);
-
-	memcpy(&span_id, data[SRPC_SPAN_ID].c_str(), 8);
-	span_id = ntohll(span_id);
-	snprintf(span_id_buf, SRPC_SPANID_SIZE * 2 + 1,
-			 "%016llx", (unsigned long long)span_id);
+	ptr = span_id_buf;
+	SPAN_ID_BUF_TO_HEX(data[SRPC_SPAN_ID].c_str(), &ptr);
 
 	size_t ret = snprintf(str, len, "trace_id: %s span_id: %s service: %s"
 									" method: %s start_time: %s",
@@ -103,13 +90,10 @@ static size_t rpc_span_log_format(RPCModuleData& data, char *str, size_t len)
 	if (iter != data.end())
 	{
 		char parent_span_id_buf[SRPC_SPANID_SIZE * 2 + 1];
-		uint64_t parent_span_id;
 
-		memcpy(&parent_span_id, data[SRPC_PARENT_SPAN_ID].c_str(), 8);
-		parent_span_id = ntohll(parent_span_id);
+		ptr = parent_span_id_buf;
+		SPAN_ID_BUF_TO_HEX(iter->second.c_str(), &ptr);
 
-		snprintf(parent_span_id_buf, SRPC_SPANID_SIZE * 2 + 1,
-				 "%016llx", (unsigned long long)parent_span_id);
 		ret += snprintf(str + ret, len - ret, " parent_span_id: %s",
 						parent_span_id_buf);
 	}

--- a/src/module/rpc_span_policies.cc
+++ b/src/module/rpc_span_policies.cc
@@ -72,11 +72,8 @@ static size_t rpc_span_log_format(RPCModuleData& data, char *str, size_t len)
 	char trace_id_buf[SRPC_TRACEID_SIZE * 2 + 1];
 	char span_id_buf[SRPC_SPANID_SIZE * 2 + 1];
 
-	char *ptr = trace_id_buf;
-	TRACE_ID_BUF_TO_HEX(data[SRPC_TRACE_ID].c_str(), &ptr);
-
-	ptr = span_id_buf;
-	SPAN_ID_BUF_TO_HEX(data[SRPC_SPAN_ID].c_str(), &ptr);
+	TRACE_ID_BUF_TO_HEX(data[SRPC_TRACE_ID].c_str(), trace_id_buf);
+	SPAN_ID_BUF_TO_HEX(data[SRPC_SPAN_ID].c_str(), span_id_buf);
 
 	size_t ret = snprintf(str, len, "trace_id: %s span_id: %s service: %s"
 									" method: %s start_time: %s",
@@ -91,9 +88,7 @@ static size_t rpc_span_log_format(RPCModuleData& data, char *str, size_t len)
 	{
 		char parent_span_id_buf[SRPC_SPANID_SIZE * 2 + 1];
 
-		ptr = parent_span_id_buf;
-		SPAN_ID_BUF_TO_HEX(iter->second.c_str(), &ptr);
-
+		SPAN_ID_BUF_TO_HEX(iter->second.c_str(), parent_span_id_buf);
 		ret += snprintf(str + ret, len - ret, " parent_span_id: %s",
 						parent_span_id_buf);
 	}

--- a/src/rpc_basic.h
+++ b/src/rpc_basic.h
@@ -153,7 +153,8 @@ static inline long long GET_CURRENT_MS_STEADY()
 			std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
-static inline void TRACE_ID_BUF_TO_HEX(const char *in, char *hex_out)
+static inline void TRACE_ID_BUF_TO_HEX(const char *in,
+									   char hex_out[SRPC_TRACEID_SIZE * 2 + 1])
 {
 	uint64_t trace_id_high;
 	uint64_t trace_id_low;
@@ -163,25 +164,24 @@ static inline void TRACE_ID_BUF_TO_HEX(const char *in, char *hex_out)
 	trace_id_high = ntohll(trace_id_high);
 	trace_id_low = ntohll(trace_id_low);
 
-	snprintf(hex_out, SRPC_TRACEID_SIZE + 1,
-			 "%016llx", (unsigned long long)trace_id_high);
-	snprintf(hex_out + SRPC_TRACEID_SIZE, SRPC_TRACEID_SIZE + 1,
-			 "%016llx", (unsigned long long)trace_id_low);
+	sprintf(hex_out, "%016llx%016llx",
+			(unsigned long long)trace_id_high,
+			(unsigned long long)trace_id_low);
 }
 
-static inline void SPAN_ID_BUF_TO_HEX(const char *in, char *hex_out)
+static inline void SPAN_ID_BUF_TO_HEX(const char *in,
+									  char hex_out[SRPC_SPANID_SIZE * 2 + 1])
 {
 	uint64_t span_id;
 
 	memcpy(&span_id, in, 8);
 	span_id = ntohll(span_id);
 
-	snprintf(hex_out, SRPC_SPANID_SIZE * 2 + 1,
-			 "%016llx", (unsigned long long)span_id);
+	sprintf(hex_out, "%016llx", (unsigned long long)span_id);
 }
 
 // here hex_in is not 'const' char *
-static inline void TRACE_ID_HEX_TO_BUF(char *hex_in, char *out)
+static inline void TRACE_ID_HEX_TO_BUF(char *hex_in, uint64_t out[2])
 {
 	uint64_t trace_id_low = strtoull(hex_in + 16, NULL, 16);
 	hex_in[16] = '\0';
@@ -190,16 +190,8 @@ static inline void TRACE_ID_HEX_TO_BUF(char *hex_in, char *out)
 	trace_id_high = htonll(trace_id_high);
 	trace_id_low = htonll(trace_id_low);
 
-	memcpy(out, &trace_id_high, SRPC_TRACEID_SIZE / 2);
-	memcpy(out + SRPC_TRACEID_SIZE / 2, &trace_id_low, SRPC_TRACEID_SIZE / 2);
-}
-
-static inline void SPAN_ID_HEX_TO_BUF(char *hex_in, char *out)
-{
-	uint64_t span_id = strtoull(hex_in, NULL, 16);
-
-	span_id = htonll(span_id);
-	memcpy(out, &span_id, SRPC_SPANID_SIZE);
+	out[0] = trace_id_high;
+	out[1] = trace_id_low;
 }
 
 } // end namespace srpc

--- a/src/rpc_basic.h
+++ b/src/rpc_basic.h
@@ -82,18 +82,6 @@ static inline uint64_t ntohll(uint64_t x)
 
 using ProtobufIDLMessage = google::protobuf::Message;
 
-static inline long long GET_CURRENT_MS()
-{
-	return std::chrono::duration_cast<std::chrono::milliseconds>(
-			std::chrono::system_clock::now().time_since_epoch()).count();
-};
-
-static inline long long GET_CURRENT_MS_STEADY()
-{
-	return std::chrono::duration_cast<std::chrono::milliseconds>(
-			std::chrono::steady_clock::now().time_since_epoch()).count();
-}
-
 enum RPCDataType
 {
 	RPCDataUndefined	=	-1,
@@ -152,6 +140,67 @@ enum RPCModuleType
 	RPCModuleMonitor	=	1,
 	RPCModuleEmpty		=	2
 };
+
+static inline long long GET_CURRENT_MS()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::system_clock::now().time_since_epoch()).count();
+};
+
+static inline long long GET_CURRENT_MS_STEADY()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+			std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+static inline void TRACE_ID_BUF_TO_HEX(const char *in, char **hex_out)
+{
+	uint64_t trace_id_high;
+	uint64_t trace_id_low;
+
+	memcpy(&trace_id_high, in, 8);
+	memcpy(&trace_id_low, in + 8, 8);
+	trace_id_high = ntohll(trace_id_high);
+	trace_id_low = ntohll(trace_id_low);
+
+	snprintf(*hex_out, SRPC_TRACEID_SIZE + 1,
+			 "%016llx", (unsigned long long)trace_id_high);
+	snprintf(*hex_out + SRPC_TRACEID_SIZE, SRPC_TRACEID_SIZE + 1,
+			 "%016llx", (unsigned long long)trace_id_low);
+}
+
+static inline void SPAN_ID_BUF_TO_HEX(const char *in, char **hex_out)
+{
+	uint64_t span_id;
+
+	memcpy(&span_id, in, 8);
+	span_id = ntohll(span_id);
+
+	snprintf(*hex_out, SRPC_SPANID_SIZE * 2 + 1,
+			 "%016llx", (unsigned long long)span_id);
+}
+
+// here hex_in is not 'const' char *
+static inline void TRACE_ID_HEX_TO_BUF(char *hex_in, char **out)
+{
+	uint64_t trace_id_low = strtoull(hex_in + 16, NULL, 16);
+	hex_in[16] = '\0';
+	uint64_t trace_id_high = strtoull(hex_in, NULL, 16);
+
+	trace_id_high = htonll(trace_id_high);
+	trace_id_low = htonll(trace_id_low);
+
+	memcpy(*out, &trace_id_high, SRPC_TRACEID_SIZE / 2);
+	memcpy((*out) + SRPC_TRACEID_SIZE / 2, &trace_id_low, SRPC_TRACEID_SIZE / 2);
+}
+
+static inline void SPAN_ID_HEX_TO_BUF(char *hex_in, char **out)
+{
+	uint64_t span_id = strtoull(hex_in, NULL, 16);
+
+	span_id = htonll(span_id);
+	memcpy(*out, &span_id, SRPC_SPANID_SIZE);
+}
 
 } // end namespace srpc
 

--- a/src/rpc_basic.h
+++ b/src/rpc_basic.h
@@ -153,7 +153,7 @@ static inline long long GET_CURRENT_MS_STEADY()
 			std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
-static inline void TRACE_ID_BUF_TO_HEX(const char *in, char **hex_out)
+static inline void TRACE_ID_BUF_TO_HEX(const char *in, char *hex_out)
 {
 	uint64_t trace_id_high;
 	uint64_t trace_id_low;
@@ -163,25 +163,25 @@ static inline void TRACE_ID_BUF_TO_HEX(const char *in, char **hex_out)
 	trace_id_high = ntohll(trace_id_high);
 	trace_id_low = ntohll(trace_id_low);
 
-	snprintf(*hex_out, SRPC_TRACEID_SIZE + 1,
+	snprintf(hex_out, SRPC_TRACEID_SIZE + 1,
 			 "%016llx", (unsigned long long)trace_id_high);
-	snprintf(*hex_out + SRPC_TRACEID_SIZE, SRPC_TRACEID_SIZE + 1,
+	snprintf(hex_out + SRPC_TRACEID_SIZE, SRPC_TRACEID_SIZE + 1,
 			 "%016llx", (unsigned long long)trace_id_low);
 }
 
-static inline void SPAN_ID_BUF_TO_HEX(const char *in, char **hex_out)
+static inline void SPAN_ID_BUF_TO_HEX(const char *in, char *hex_out)
 {
 	uint64_t span_id;
 
 	memcpy(&span_id, in, 8);
 	span_id = ntohll(span_id);
 
-	snprintf(*hex_out, SRPC_SPANID_SIZE * 2 + 1,
+	snprintf(hex_out, SRPC_SPANID_SIZE * 2 + 1,
 			 "%016llx", (unsigned long long)span_id);
 }
 
 // here hex_in is not 'const' char *
-static inline void TRACE_ID_HEX_TO_BUF(char *hex_in, char **out)
+static inline void TRACE_ID_HEX_TO_BUF(char *hex_in, char *out)
 {
 	uint64_t trace_id_low = strtoull(hex_in + 16, NULL, 16);
 	hex_in[16] = '\0';
@@ -190,16 +190,16 @@ static inline void TRACE_ID_HEX_TO_BUF(char *hex_in, char **out)
 	trace_id_high = htonll(trace_id_high);
 	trace_id_low = htonll(trace_id_low);
 
-	memcpy(*out, &trace_id_high, SRPC_TRACEID_SIZE / 2);
-	memcpy((*out) + SRPC_TRACEID_SIZE / 2, &trace_id_low, SRPC_TRACEID_SIZE / 2);
+	memcpy(out, &trace_id_high, SRPC_TRACEID_SIZE / 2);
+	memcpy(out + SRPC_TRACEID_SIZE / 2, &trace_id_low, SRPC_TRACEID_SIZE / 2);
 }
 
-static inline void SPAN_ID_HEX_TO_BUF(char *hex_in, char **out)
+static inline void SPAN_ID_HEX_TO_BUF(char *hex_in, char *out)
 {
 	uint64_t span_id = strtoull(hex_in, NULL, 16);
 
 	span_id = htonll(span_id);
-	memcpy(*out, &span_id, SRPC_SPANID_SIZE);
+	memcpy(out, &span_id, SRPC_SPANID_SIZE);
 }
 
 } // end namespace srpc

--- a/src/rpc_context.h
+++ b/src/rpc_context.h
@@ -71,7 +71,7 @@ public:
 	virtual void set_reply_callback(std::function<void (RPCContext *ctx)> cb) = 0;
 	virtual void set_send_timeout(int timeout) = 0;
 	virtual void set_keep_alive(int timeout) = 0;
-	virtual void set_http_code(int code) = 0;
+	virtual bool set_http_code(const char *code) = 0;
 	virtual void log(const RPCLogVector& fields) = 0;
 	virtual void baggage(const std::string& key, const std::string& value) = 0;
 	//virtual void noreply();

--- a/src/rpc_context.h
+++ b/src/rpc_context.h
@@ -51,7 +51,8 @@ public:
 	virtual const std::string& get_method_name() const = 0;
 
 	virtual SeriesWork *get_series() const = 0;
-	virtual std::string get_http_header(std::string& name) const = 0;
+	virtual bool get_http_header(const std::string& name,
+								 std::string& value) const = 0;
 
 public:
 	// for client-done
@@ -72,8 +73,8 @@ public:
 	virtual void set_reply_callback(std::function<void (RPCContext *ctx)> cb) = 0;
 	virtual void set_send_timeout(int timeout) = 0;
 	virtual void set_keep_alive(int timeout) = 0;
-	virtual bool set_http_code(const char *code) = 0;
-	virtual bool set_http_header(const char *name, const char *value) = 0;
+	virtual bool set_http_code(int code) = 0;
+	virtual bool set_http_header(const std::string& name, const std::string& value) = 0;
 	virtual void log(const RPCLogVector& fields) = 0;
 	virtual void baggage(const std::string& key, const std::string& value) = 0;
 	//virtual void noreply();

--- a/src/rpc_context.h
+++ b/src/rpc_context.h
@@ -51,6 +51,7 @@ public:
 	virtual const std::string& get_method_name() const = 0;
 
 	virtual SeriesWork *get_series() const = 0;
+	virtual std::string get_http_header(std::string& name) const = 0;
 
 public:
 	// for client-done
@@ -72,6 +73,7 @@ public:
 	virtual void set_send_timeout(int timeout) = 0;
 	virtual void set_keep_alive(int timeout) = 0;
 	virtual bool set_http_code(const char *code) = 0;
+	virtual bool set_http_header(const char *name, const char *value) = 0;
 	virtual void log(const RPCLogVector& fields) = 0;
 	virtual void baggage(const std::string& key, const std::string& value) = 0;
 	//virtual void noreply();

--- a/src/rpc_context.inl
+++ b/src/rpc_context.inl
@@ -119,12 +119,12 @@ public:
 			return task_->get_resp()->get_attachment_nocopy(attachment, len);
 	}
 
-	std::string get_http_header(std::string& name) const override
+	bool get_http_header(const std::string& name, std::string& value) const override
 	{
 		if (this->is_server_task())
-			return task_->get_req()->get_http_header(name);
+			return task_->get_req()->get_http_header(name, value);
 		else
-			return task_->get_resp()->get_http_header(name);
+			return task_->get_resp()->get_http_header(name, value);
 	}
 
 public:
@@ -172,7 +172,7 @@ public:
 		}
 	}
 
-	bool set_http_code(const char *code) override
+	bool set_http_code(int code) override
 	{
 		if (this->is_server_task())
 			return task_->get_resp()->set_http_code(code);
@@ -180,7 +180,7 @@ public:
 		return false;
 	}
 
-	bool set_http_header(const char *name, const char *value) override
+	bool set_http_header(const std::string& name, const std::string& value) override
 	{
 		if (this->is_server_task())
 			return task_->get_resp()->set_http_header(name, value);

--- a/src/rpc_context.inl
+++ b/src/rpc_context.inl
@@ -119,6 +119,14 @@ public:
 			return task_->get_resp()->get_attachment_nocopy(attachment, len);
 	}
 
+	std::string get_http_header(std::string& name) const override
+	{
+		if (this->is_server_task())
+			return task_->get_req()->get_http_header(name);
+		else
+			return task_->get_resp()->get_http_header(name);
+	}
+
 public:
 	// for client-done
 	bool success() const override
@@ -167,7 +175,17 @@ public:
 	bool set_http_code(const char *code) override
 	{
 		if (this->is_server_task())
-			task_->get_resp()->set_http_code(code);
+			return task_->get_resp()->set_http_code(code);
+
+		return false;
+	}
+
+	bool set_http_header(const char *name, const char *value) override
+	{
+		if (this->is_server_task())
+			return task_->get_resp()->set_http_header(name, value);
+
+		return false;
 	}
 
 	void log(const RPCLogVector& fields) override { }

--- a/src/rpc_context.inl
+++ b/src/rpc_context.inl
@@ -164,7 +164,7 @@ public:
 		}
 	}
 
-	void set_http_code(int code) override
+	bool set_http_code(const char *code) override
 	{
 		if (this->is_server_task())
 			task_->get_resp()->set_http_code(code);

--- a/src/rpc_task.inl
+++ b/src/rpc_task.inl
@@ -123,6 +123,8 @@ public:
 	// Baggage Items, which are just key:value pairs that cross process boundaries
 	void baggage(const std::string& key, const std::string& value);
 
+	bool set_http_header(const char *name, const char *value);
+
 	// JsonPrintOptions
 	void set_json_add_whitespace(bool on);
 	void set_json_always_print_enums_as_ints(bool on);
@@ -704,6 +706,12 @@ template<class RPCREQ, class RPCRESP>
 inline void RPCClientTask<RPCREQ, RPCRESP>::set_json_always_print_primitive_fields(bool on)
 {
 	this->req.set_json_print_primitive(on);
+}
+
+template<class RPCREQ, class RPCRESP>
+inline bool RPCClientTask<RPCREQ, RPCRESP>::set_http_header(const char *name, const char *value)
+{
+	return this->req.set_http_header(name, value);
 }
 
 } // namespace srpc


### PR DESCRIPTION
### Description:
1. Support `set_http_header()` / `get_http_header()`; 
- For client, the APIs are on the **RPCClientTask**;
- For server, the APIs are on the **RPCContext**;

2. Change the format of **Trace-Id** / **Span-Id** into Hex, make them more readable;

### Server Example:

~~~cpp
class ExampleServiceImpl : public Example::Service                              
{                                                                               
public:                                                                         
    void Echo(EchoRequest *req, EchoResponse *resp, RPCContext *ctx) override   
    {                                                                           
        std::string value;                                                      
        ctx->get_http_header("client_baggage", value);  // get http header                        

        resp->set_message("Hi back");                                           
        ctx->set_http_code(404); // set http code                                              
        ctx->set_http_header("srpc server header", "srpc method Echo"); // set http header        
                                                                                
        printf("Server Echo()\nget_req:\n%s\nget http_header <client_baggage:%s>\nset_resp:\n%s\n",
                req->DebugString().c_str(), value.c_str(), resp->DebugString().c_str());
    }                                                                           
}; 

int main()
{                             
    SRPCHttpServer server;                                       
    RPCSpanDefault span_log;                                                    
    server.add_filter(&span_log);
    ...
}
~~~

### CURL  Command:
~~~sh
curl -i 127.0.0.1:1412/Example/Echo -H 'Content-Type: application/json' -d '{messageRL"}' -H 'Trace-Id: 00e002817305252402e0028173052524' -H "client_baggage:client_baggage_value" -H "Span-ID: 04e06fb604b84e24"
~~~

### Server Output:
~~~sh
Server Echo()
get_req:
message: "from curl"
name: "CURL"

get http_header <client_baggage:client_baggage_value>
set_resp:
message: "Hi back"

[SPAN_LOG] trace_id: 00e002817305252402e0028173052524 span_id: 00e0f821c7695024 service: Example method: Echo start_time: 1647003699730 parent_span_id: 04e06fb604b84e24 finish_time: 1647003699731 duration: 1 remote_ip: 127.0.0.1 port: 40894 state: 1 error: 0
~~~