### PR TITLE
fix rpc_var.cc compile error on windows and some bugs

### DIFF
--- a/src/var/rpc_var.h
+++ b/src/var/rpc_var.h
@@ -262,7 +262,9 @@ class HistogramVar : public RPCVar
 {
 public:
 	void observe(double value);
-	bool observe_multi(const std::vector<double>& multi, double sum);
+
+	// multi is the histogram count of each bucket, including +inf
+	bool observe_multi(const std::vector<size_t>& multi, double sum);
 
 	RPCVar *create(bool with_data) override;
 	bool reduce(const void *ptr, size_t sz) override;


### PR DESCRIPTION
可以通过的测试如下：

~~~sh
valgrind --leak-check=full ./tutorial/server_with_metrics
~~~

~~~sh
[@gdylj_35_53 example]# /search/ted/srpc_1412/tutorial/srpc_pb_client 
message: "Hi back"

message: "Hi back"

^C
[@gdylj_35_53 example]# /search/ted/srpc_1412/tutorial/srpc_pb_client 
message: "Hi back"

message: "Hi back"

^C
[@gdylj_35_53 example]# /search/ted/srpc_1412/tutorial/srpc_pb_client 
message: "Hi back"

message: "Hi back"

^C
[@gdylj_35_53 example]# curl localhost:8080/metrics
# HELP total_request_count total request count
# TYPE total_request_count gauge
total_request_count 6.000000
# HELP total_request_method request method statistics
# TYPE total_request_method counter
total_request_method{method="Echo",service="Example"} 6.000000
# HELP total_request_latency request latency nano seconds
# TYPE total_request_latency summary
total_request_latency{quantile="0.500000"} 2679120.000000
total_request_latency{quantile="0.900000"} 174216489.000000
total_request_latency_sum 184336578.000000
total_request_latency_count 6
# HELP echo_request_size Echo request size
# TYPE echo_request_size histogram
echo_request_size_bucket{le="1.000000"} 0
echo_request_size_bucket{le="10.000000"} 0
echo_request_size_bucket{le="100.000000"} 6
echo_request_size_bucket{le="+Inf"} 6
echo_request_size_sum 120.000000
echo_request_size_count 6
# HELP echo_test_quantiles Test quantile
# TYPE echo_test_quantiles summary
echo_test_quantiles{quantile="0.500000"} 0.040000
echo_test_quantiles{quantile="0.900000"} 0.080000
echo_test_quantiles_sum 3.300000
echo_test_quantiles_count 60
[@gdylj_35_53 example]# /search/ted/srpc_1412/tutorial/srpc_pb_client 
message: "Hi back"

message: "Hi back"

^C
[@gdylj_35_53 example]# curl localhost:8080/metrics
# HELP total_request_count total request count
# TYPE total_request_count gauge
total_request_count 8.000000
# HELP total_request_method request method statistics
# TYPE total_request_method counter
total_request_method{method="Echo",service="Example"} 8.000000
# HELP total_request_latency request latency nano seconds
# TYPE total_request_latency summary
total_request_latency{quantile="0.500000"} 2642570.000000
total_request_latency{quantile="0.900000"} 2679120.000000
total_request_latency_sum 187646001.000000
total_request_latency_count 8
# HELP echo_request_size Echo request size
# TYPE echo_request_size histogram
echo_request_size_bucket{le="1.000000"} 0
echo_request_size_bucket{le="10.000000"} 0
echo_request_size_bucket{le="100.000000"} 8
echo_request_size_bucket{le="+Inf"} 8
echo_request_size_sum 160.000000
echo_request_size_count 8
# HELP echo_test_quantiles Test quantile
# TYPE echo_test_quantiles summary
echo_test_quantiles{quantile="0.500000"} 0.050000
echo_test_quantiles{quantile="0.900000"} 0.090000
echo_test_quantiles_sum 4.400000
echo_test_quantiles_count 80
~~~