### PR TITLE
fix error when compile tutorial on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if (WIN32)
 				CMAKE_C_FLAGS_MINSIZEREL
 				)
 		foreach(CompilerFlag ${CompilerFlags})
-			string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+			#string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}") # this line will make tutorial compile error
 		endforeach ()
 	endif ()
 endif ()

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -105,7 +105,7 @@ if (WIN32)
 				CMAKE_C_FLAGS_MINSIZEREL
 				)
 		foreach(CompilerFlag ${CompilerFlags})
-			string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+			#string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}") # MD is fine, or this line will make compile error
 		endforeach ()
 	endif ()
 endif ()


### PR DESCRIPTION
fix error when compile tutorial on Windows: change the run time library from MT to MD(default), workflow is MD,  change srpc RT same with workflow.