### PR TITLE
Add vcpkg installation instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ To install the srpc library for deployment:
 sudo apt-get install libsrpc
 ~~~~
 
+### Installing srpc (vcpkg)
+
+Alternatively, you can build and install srpc using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+~~~~sh or powershell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install srpc
+~~~~
+The srpc port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Tutorial
 
 * [Step 1: Design IDL description file](/docs/en/docs-01-idl.md)

--- a/README_cn.md
+++ b/README_cn.md
@@ -68,6 +68,18 @@ cd srpc
 make
 ~~~
 
+### Installing srpc (vcpkg)
+  * 或者，你可以通过vcpkg包依赖管理器来构建和下载srpc
+ ~~~~sh or powershell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install srpc
+~~~~
+
+  * vcpkg当中的srpc由Microsoft的团队成员和社区贡献者一起维护并保持最新的版本。如果发现版本过时，随时向[vcpkg](https://github.com/Microsoft/vcpkg)提交一个issue或者 Pull Request.
+
 ## Tutorial
 
 * [第1步：设计IDL描述文件](docs/docs-01-idl.md)


### PR DESCRIPTION
`srpc` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `srpc` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `srpc`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/srpc/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊