### PR TITLE
replace std::numeric_limits<double>::max() with DBL_MAX

### DIFF
--- a/src/module/rpc_filter_metrics.cc
+++ b/src/module/rpc_filter_metrics.cc
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <limits>
+#include <cfloat>
 #include <string>
 #include <set>
 #include <vector>
@@ -311,7 +311,7 @@ void RPCMetricsPull::Collector::collect_histogram_each(RPCVar *histogram,
 													   size_t current_count)
 {
 	this->report_output += histogram->get_name();
-	if (bucket_boundary != std::numeric_limits<double>::max())
+	if (bucket_boundary != DBL_MAX)
 	{
 		this->report_output += "_bucket{le=\"" +
 							   std::to_string(bucket_boundary) + "\"} ";
@@ -593,7 +593,7 @@ void RPCMetricsOTel::Collector::collect_histogram_each(RPCVar *histogram,
 	HistogramDataPoint *data_points = static_cast<HistogramDataPoint *>(this->current_msg);
 	data_points->add_bucket_counts(current_count);
 
-	if (bucket_boundary != std::numeric_limits<double>::max())
+	if (bucket_boundary != DBL_MAX)
 		data_points->add_explicit_bounds(bucket_boundary);
 }
 

--- a/src/var/rpc_var.cc
+++ b/src/var/rpc_var.cc
@@ -16,6 +16,7 @@
 
 #include <mutex>
 #include <string>
+#include <cfloat>
 #include <vector>
 #include <unordered_map>
 #include "rpc_var.h"
@@ -348,9 +349,7 @@ void HistogramVar::collect(RPCVarCollector *collector)
 	}
 
 	current += this->bucket_counts[i];
-	collector->collect_histogram_each(this, std::numeric_limits<double>::max(),
-									  current);
-
+	collector->collect_histogram_each(this, DBL_MAX, current);
 	collector->collect_histogram_end(this, this->sum, this->count);
 }
 


### PR DESCRIPTION
It seems that some compilers like MSVC will include a default max() and then `std::numeric_limits<double>::max()` will cause a compile error.
Using `DBL_MAX` is the proper way.
Refer to : https://github.com/sogou/srpc/issues/221#issuecomment-1276972936