### PR TITLE
Improve the directory to find dependent proto files.

### DIFF
--- a/docs/en/rpc.md
+++ b/docs/en/rpc.md
@@ -14,7 +14,7 @@
 ## Basic concepts
 
 - Communication layer: TCP/TPC\_SSL/HTTP/HTTPS/HTTP2
-- Protocol layer: Thrift-binary/BRPC-std/SRPC-http/tRPC-std/tRPC-http
+- Protocol layer: Thrift-binary/BRPC-std/SRPC-std/SRPC-http/tRPC-std/tRPC-http
 - Compression layer: no compression/gzip/zlib/lz4/snappy
 - Data layer: PB binary/Thrift binary/JSON string
 - IDL serialization layer: PB/Thrift serialization

--- a/src/generator/parser.cc
+++ b/src/generator/parser.cc
@@ -58,9 +58,14 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 	{
 		info.file_name = proto_file.substr(pos + 1);
 
-		getcwd(current_dir, MAXPATHLEN);
-		dir_prefix = current_dir;
-		dir_prefix += "/";
+		if (proto_file[0] == '/')
+			dir_prefix = proto_file.substr(0, pos + 1);
+		else
+		{
+			getcwd(current_dir, MAXPATHLEN);
+			dir_prefix = current_dir;
+			dir_prefix += "/";
+		}
 	}
 
 	pos = info.file_name.find_last_of('.');


### PR DESCRIPTION
When we use multiple proto files like:

/home/srpc/tutorial/example.proto
```proto
import "request.proto";
...
```
/home/srpc/tutorial/request.proto
```proto
message REQ {...}
```
srpc_generator can build `example.srpc.h` recursively. 

And this Pull Request is going to fix the way to find the `file` directory instead of `execute` directory. The following command can be executed anywhere when we use the absolute directory of the proto file.
```sh
srpc_generator protobuf /home/srpc/tutorial/example.proto ./
```
