### PR TITLE
Add operation.name in trace and metrics attributes

### DIFF
--- a/src/module/rpc_filter.h
+++ b/src/module/rpc_filter.h
@@ -27,7 +27,8 @@ namespace srpc
 {
 static constexpr unsigned int	OTLP_HTTP_REDIRECT_MAX		= 0;
 static constexpr unsigned int	OTLP_HTTP_RETRY_MAX			= 1;
-static constexpr const char	   *OTLP_SERVICE_NAME_KEY		= "service.name";
+static constexpr const char	   *OTLP_SERVICE_NAME			= "service.name";
+static constexpr const char	   *OTLP_METHOD_NAME			= "operation.name";
 static constexpr size_t			RPC_REPORT_THREHOLD_DEFAULT	= 100;
 static constexpr size_t			RPC_REPORT_INTERVAL_DEFAULT	= 1000; /* msec */
 

--- a/src/module/rpc_module.h
+++ b/src/module/rpc_module.h
@@ -34,8 +34,6 @@ static constexpr char const *SRPC_SPAN_MESSAGE		= "message";
 static constexpr char const *SRPC_START_TIMESTAMP	= "srpc.start_time";
 static constexpr char const *SRPC_FINISH_TIMESTAMP	= "srpc.finish_time";
 static constexpr char const *SRPC_DURATION			= "srpc.duration";
-static constexpr char const *SRPC_SERVICE_NAME		= "srpc.service.name";
-static constexpr char const *SRPC_METHOD_NAME		= "srpc.operation";
 
 //for SnowFlake: u_id = [timestamp][group][machine][sequence]
 static constexpr int SRPC_TIMESTAMP_BITS		= 38;

--- a/src/module/rpc_module_metrics.h
+++ b/src/module/rpc_module_metrics.h
@@ -39,8 +39,8 @@ public:
 		auto *req = client_task->get_req();
 		RPCModuleData& module_data = *(client_task->mutable_module_data());	
 
-		module_data[SRPC_SERVICE_NAME] = req->get_service_name();
-		module_data[SRPC_METHOD_NAME] = req->get_method_name();
+		module_data[OTLP_SERVICE_NAME] = req->get_service_name();
+		module_data[OTLP_METHOD_NAME] = req->get_method_name();
 		if (module_data.find(SRPC_START_TIMESTAMP) == module_data.end())
 			module_data[SRPC_START_TIMESTAMP] = std::to_string(GET_CURRENT_NS());
 
@@ -67,8 +67,8 @@ public:
 		auto *req = server_task->get_req();
 		RPCModuleData& module_data = *(server_task->mutable_module_data());
 
-		module_data[SRPC_SERVICE_NAME] = req->get_service_name();
-		module_data[SRPC_METHOD_NAME] = req->get_method_name();
+		module_data[OTLP_SERVICE_NAME] = req->get_service_name();
+		module_data[OTLP_METHOD_NAME] = req->get_method_name();
 		if (module_data.find(SRPC_START_TIMESTAMP) == module_data.end())
 			module_data[SRPC_START_TIMESTAMP] = std::to_string(GET_CURRENT_NS());
 

--- a/src/module/rpc_module_span.h
+++ b/src/module/rpc_module_span.h
@@ -115,14 +115,15 @@ bool RPCSpanModule<RPCTYPE>::client_begin(SubTask *task,
 	module_data[SRPC_COMPONENT] = SRPC_COMPONENT_SRPC;
 	module_data[SRPC_SPAN_KIND] = SRPC_SPAN_KIND_CLIENT;
 
-	module_data[SRPC_SERVICE_NAME] = req->get_service_name();
-	module_data[SRPC_METHOD_NAME] = req->get_method_name();
+	module_data[OTLP_SERVICE_NAME] = req->get_service_name();
+	module_data[OTLP_METHOD_NAME] = req->get_method_name();
 	module_data[SRPC_DATA_TYPE] = std::to_string(req->get_data_type());
 	module_data[SRPC_COMPRESS_TYPE] =
 							std::to_string(req->get_compress_type());
 	if (module_data.find(SRPC_START_TIMESTAMP) == module_data.end())
 		module_data[SRPC_START_TIMESTAMP] = std::to_string(GET_CURRENT_NS());
-	return true; // always success
+
+	return true;
 }
 
 template<class RPCTYPE>
@@ -163,8 +164,8 @@ bool RPCSpanModule<RPCTYPE>::server_begin(SubTask *task,
 	auto *req = server_task->get_req();
 	RPCModuleData& module_data = *(server_task->mutable_module_data());
 
-	module_data[SRPC_SERVICE_NAME] = req->get_service_name();
-	module_data[SRPC_METHOD_NAME] = req->get_method_name();
+	module_data[OTLP_SERVICE_NAME] = req->get_service_name();
+	module_data[OTLP_METHOD_NAME] = req->get_method_name();
 	module_data[SRPC_DATA_TYPE] = std::to_string(req->get_data_type());
 	module_data[SRPC_COMPRESS_TYPE] =
 							std::to_string(req->get_compress_type());


### PR DESCRIPTION
New change:
- Add `operation.name` field in both trace and metrics information to report to OpenTelemetry.
- Fix `service.name` field overwritten by a null string.

Now the trace request looks like:

~~~sh
resource_spans {
  resource {
    attributes {
      key: "operation.name"
      value {
        string_value: "Echo"
      }
    }
    attributes {
      key: "other_attribute_key_1"
      value {
        string_value: "other_attribute_value_1"
      }
    }
    attributes {
      key: "service.name"
      value {
        string_value: "Example"
      }
    }
  }
  instrumentation_library_spans {
  }
}
~~~
The `service.name` and `operation.name` will be set by default. And according to the [OpenTelemetry semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions), the framework `service.name` has higher priority than user attributes.