### PR TITLE
srpc_generator supports getopt_long and more params.

### DIFF
--- a/src/generator/compiler.cc
+++ b/src/generator/compiler.cc
@@ -16,12 +16,20 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <getopt.h>
+#include <string>
+
 #ifdef _WIN32
 #include <direct.h>
+#define MAXPATHLEN 4096
 #else
 #include <unistd.h>
+#include <sys/param.h>
 #endif
+
 #include "generator.h"
+
+const char *SRPC_VERSION = "0.9.8";
 
 /* LQ - prototype to determine if the file type is thrift */
 enum
@@ -31,87 +39,188 @@ enum
 	TYPE_THRIFT = 1,
 };
 
-const char *SRPC_VERSION = "0.9.8";
+static int check_file_idl_type(const char *filename);
+static int parse_origin(int argc, const char *argv[],
+						struct GeneratorParams& params,
+						int& idl_type);
+static int parse_getopt(int argc, char * const *argv,
+						struct GeneratorParams& params,
+						int& idl_type);
+static int parse_prefix_dir(std::string& file, std::string& dir);
+static int get_idl_type(const char *argv);
+static bool is_root(std::string& file);
 
-static int check_idl_type(const char *filename);
 const char *SRPC_GENERATOR_USAGE = "\
-Usage:\n\t%s [protobuf|thrift] <idl_file> <output_dir>\n";
+Usage:\n\
+    %s [protobuf|thrift] <idl_file> <output_dir>\n\n\
+Available options:\n\
+    -f, --idl_file      : IDL file name. If multiple files are imported, specify the top one. Will parse recursively.\n\
+    -o, --output_dir    : Output directory.\n\
+    -i, --input_dir     : Specify the directory in which to search for imports.\n\
+    -s, --skip_skeleton : Skip generating skeleton file. (default: generate)\n\
+    -v, --version       : Show version.\n\
+    -h, --help          : Show usage.\n";
 
 int main(int argc, const char *argv[])
 {
-	/* LQ - update to use 2 command line arguments */
-	/* TODO: use optarg/getopt_long to have index-independent arguments? */
-	/*   Ex: srpc_generator -i <IDL_FILE> -o <OUTPUT_DIR> or */
-	/*       srpc_generator --input <IDL_FILE> --output <OUTPUT_DIR> */
+	int idl_type = TYPE_UNKNOWN;
+	struct GeneratorParams params;
 
-	int idl_type;
-	int idl_file_id = 1;
-
-	if (argc == 2 &&
-		(strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--version") == 0))
+	if (parse_origin(argc, argv, params, idl_type) == 0)
 	{
-		fprintf(stderr, "srpc_generator version %s\n", SRPC_VERSION);
-		return 0;
-	}
-	else if (argc == 3)
-	{
-		idl_type = check_idl_type(argv[1]);
-		if (idl_type == TYPE_UNKNOWN)
-		{
-			fprintf(stderr, "ERROR: Invalid IDL file \"%s\"\n", argv[1]);
-			fprintf(stderr, SRPC_GENERATOR_USAGE, argv[0]);
+		if (parse_getopt(argc, (char * const *)argv, params, idl_type) != 0)
 			return 0;
-		}
 	}
-	else if (argc == 4)
-	{
-		if (strcasecmp(argv[1], "protobuf") == 0)
-			idl_type = TYPE_PROTOBUF;
-		else if (strcasecmp(argv[1], "thrift") == 0)
-			idl_type = TYPE_THRIFT;
-		else
-		{
-			fprintf(stderr, "ERROR: Invalid IDL type \"%s\"\n", argv[1]);
-			fprintf(stderr, SRPC_GENERATOR_USAGE, argv[0]);
-			return 0;
-		}
 
-		idl_file_id++;
-	}
-	else
+	if (params.out_dir == NULL || params.idl_file.empty())
 	{
 		fprintf(stderr, SRPC_GENERATOR_USAGE, argv[0]);
 		return 0;
 	}
 
-	const char *idl_file = argv[idl_file_id];
-	struct GeneratorParams params;
-	Generator gen(idl_type == TYPE_THRIFT ? true : false);
+	if (idl_type == TYPE_UNKNOWN)
+		idl_type = check_file_idl_type(params.idl_file.data());
 
-	params.out_dir = argv[idl_file_id + 1];
-
-	char file_name[DIRECTORY_LENGTH] = { 0 };
-	size_t pos = 0;
-
-	if (idl_file[0] != '/' && idl_file[1] != ':')
+	if (is_root(params.idl_file))
 	{
-		getcwd(file_name, DIRECTORY_LENGTH);
-		pos = strlen(file_name) + 1;
-		file_name[strlen(file_name)] = '/';
+		if (params.input_dir.empty())
+			parse_prefix_dir(params.idl_file, params.input_dir);
+		else
+		{
+			fprintf(stderr, "ERROR: input_dir must encompasses the idl_file %s\n",
+					params.idl_file.c_str());
+			return 0;
+		}
+	}
+	else
+	{
+		if (params.input_dir.empty() || is_root(params.input_dir) == false)
+		{
+			char current_dir[MAXPATHLEN] = {};
+			getcwd(current_dir, MAXPATHLEN);
+			current_dir[strlen(current_dir)] = '/';
+
+			if (params.input_dir.empty())
+				params.input_dir = current_dir;
+			else
+				params.input_dir = current_dir +  params.input_dir;
+		}
 	}
 
-	if (strlen(idl_file) >= 2 && idl_file[0] == '.' && idl_file[1] == '/')
-		idl_file += 2;
-
-	snprintf(file_name + pos, DIRECTORY_LENGTH - pos, "%s", idl_file);
+	Generator gen(idl_type == TYPE_THRIFT ? true : false);
 
 	fprintf(stdout, "[Generator Begin]\n");
-	gen.generate(file_name, params);
+	gen.generate(params);
 	fprintf(stdout, "[Generator Done]\n");
 	return 0;
 }
 
-int check_idl_type(const char *filename)
+int parse_origin(int argc, const char *argv[],
+				 struct GeneratorParams& params, int& idl_type)
+{
+	int idl_file_id = 1;
+
+	for (size_t i = 1; i < argc && i < 4 && argv[i][0] != '-'; i++)
+	{
+		if (i == 1) // parse [protobuf|thrift]
+		{
+			idl_type = get_idl_type(argv[1]);
+
+			if (idl_type != TYPE_UNKNOWN)
+			{
+				idl_file_id++;
+				continue;
+			}
+		}
+
+		if (i == idl_file_id) // parse <idl_file>
+		{
+			int tmp_type = check_file_idl_type(argv[i]);
+			if (tmp_type == TYPE_UNKNOWN)
+			{
+				fprintf(stderr, "ERROR: Invalid IDL file \"%s\".\n", argv[i]);
+				return -1;
+			}
+
+			if (idl_type == TYPE_UNKNOWN)
+				idl_type = tmp_type;
+
+			params.idl_file = argv[idl_file_id];
+		}
+		else // parse <output_dir>
+			params.out_dir = argv[i];
+	}
+
+	return 0;
+}
+
+int parse_getopt(int argc, char * const *argv,
+				 struct GeneratorParams& params, int& idl_type)
+{
+	int ch;
+
+	static struct option longopts[] = {
+		{ "version",       no_argument,       NULL, 'v'},
+		{ "idl_file",      required_argument, NULL, 'f'},
+		{ "output_dir",    required_argument, NULL, 'o'},
+		{ "input_dir",     required_argument, NULL, 'i'},
+		{ "skip_skeleton", no_argument,       NULL, 's'},
+		{ "help",          no_argument,       NULL, 'h'}
+	};
+
+	while ((ch = getopt_long(argc, argv, "vf:o:i:sh", longopts, NULL)) != 1)
+	{
+		switch (ch)
+		{
+		case 'v':
+			fprintf(stderr, "srpc_generator version %s\n", SRPC_VERSION);
+			return 1;
+		case 'f':
+			if (!params.idl_file.empty())
+			{
+				fprintf(stderr, "Error: -i is duplicate with idl_file %s\n",
+						params.idl_file.c_str());
+				return -1;
+			}
+			params.idl_file = optarg;
+			break;
+		case 'o':
+			if (params.out_dir != NULL)
+			{
+				fprintf(stderr, "Error: -o is duplicate with output_dir %s\n",
+						params.out_dir);
+				return -1;
+			}
+			params.out_dir = optarg;
+			break;
+		case 'i':
+			params.input_dir = optarg;
+			break;
+		case 's':
+			params.generate_skeleton = false;
+			break;
+		case 'h':
+			break;
+		default:
+			return 0;
+		}
+	}
+
+	return 0;
+}
+
+int get_idl_type(const char *type)
+{
+	if (strcasecmp(type, "protobuf") == 0)
+		return TYPE_PROTOBUF;
+	if (strcasecmp(type, "thrift") == 0)
+		return TYPE_THRIFT;
+
+	return TYPE_UNKNOWN;
+}
+
+// idl file will not start with -
+int check_file_idl_type(const char *filename)
 {
 	size_t len = strlen(filename);
 
@@ -123,3 +232,22 @@ int check_idl_type(const char *filename)
 	return TYPE_UNKNOWN;
 }
 
+int parse_prefix_dir(std::string& file, std::string& dir)
+{
+	auto pos = file.find_last_of('/');
+	if (pos == std::string::npos)
+		return -1;
+
+	dir = file.substr(0, pos + 1);
+	file = file.substr(pos + 1);
+
+	return 0;
+}
+
+bool is_root(std::string& file)
+{
+	if (file[0] == '/' || file[1] == ':')
+		return true;
+
+	return false;
+}

--- a/src/generator/descriptor.h
+++ b/src/generator/descriptor.h
@@ -71,6 +71,7 @@ struct Descriptor
 struct idl_info
 {
 	std::string file_name;
+	std::string input_dir;
 	std::string absolute_file_path;
 	std::string file_name_prefix;
 	std::vector<std::string> package_name;

--- a/src/generator/generator.cc
+++ b/src/generator/generator.cc
@@ -74,8 +74,11 @@ bool Generator::init_file_names(const std::string& idl_file, const char *out_dir
 	return true;
 }
 
-bool Generator::generate(const std::string& idl_file, struct GeneratorParams params)
+bool Generator::generate(struct GeneratorParams& params)
 {
+	this->info.input_dir = params.input_dir;
+	std::string idl_file = params.input_dir + params.idl_file;
+
 	if (this->parser.parse(idl_file, this->info) == false)
 	{
 		fprintf(stderr, "[Generator Error] parse failed.\n");
@@ -88,12 +91,13 @@ bool Generator::generate(const std::string& idl_file, struct GeneratorParams par
 		return false;
 	}
 
-	this->generate_skeleton(this->info.file_name);
+	if (params.generate_skeleton == true)
+		this->generate_skeleton(this->info.file_name);
 
 	return true;
 }
 
-bool Generator::generate_header(idl_info& cur_info, struct GeneratorParams params)
+bool Generator::generate_header(idl_info& cur_info, struct GeneratorParams& params)
 {
 	for (auto& sub_info : cur_info.include_list)
 	{
@@ -173,16 +177,6 @@ void Generator::generate_skeleton(const std::string& idl_file)
 		return;
 
 	std::string idl_file_name = str.substr(0, pos);
-
-	this->server_cpp_file = this->out_dir;
-	this->server_cpp_file.append("server");
-	this->server_cpp_file.append(this->is_thrift ? ".thrift_skeleton." : ".pb_skeleton.");
-	this->server_cpp_file.append("cc");
-
-	this->client_cpp_file = this->out_dir;
-	this->client_cpp_file.append("client");
-	this->client_cpp_file.append(this->is_thrift ? ".thrift_skeleton." : ".pb_skeleton.");
-	this->client_cpp_file.append("cc");
 
 	// server.skeleton.cc
 	this->generate_server_cpp_file(this->info, idl_file_name);
@@ -366,9 +360,16 @@ bool Generator::generate_srpc_file(const idl_info& cur_info)
 	return true;
 }
 
-void Generator::generate_server_cpp_file(const idl_info& cur_info, const std::string& idl_file_name)
+bool Generator::generate_server_cpp_file(const idl_info& cur_info,
+										 const std::string& idl_file_name)
 {
-	this->printer.open(this->server_cpp_file);
+	this->server_cpp_file = this->out_dir;
+	this->server_cpp_file.append("server");
+	this->server_cpp_file.append(this->is_thrift ? ".thrift_skeleton." : ".pb_skeleton.");
+	this->server_cpp_file.append("cc");
+
+	if (this->printer.open(this->server_cpp_file) == false)
+		return false;
 
 	this->printer.print_server_file_include(idl_file_name);
 
@@ -391,6 +392,8 @@ void Generator::generate_server_cpp_file(const idl_info& cur_info, const std::st
 	}
 
 	this->printer.print_server_main_begin();
+	this->printer.print_server_main_address();
+
 	for (const auto& desc : cur_info.desc_list)
 	{
 		if (desc.block_type != "service")
@@ -400,13 +403,22 @@ void Generator::generate_server_cpp_file(const idl_info& cur_info, const std::st
 	}
 
 	this->printer.print_server_main_end();
-
+	this->printer.print_server_main_return();
 	this->printer.close();
+
+	return true;
 }
 
-void Generator::generate_client_cpp_file(const idl_info& cur_info, const std::string& idl_file_name)
+bool Generator::generate_client_cpp_file(const idl_info& cur_info,
+										 const std::string& idl_file_name)
 {
-	this->printer.open(this->client_cpp_file);
+	this->client_cpp_file = this->out_dir;
+	this->client_cpp_file.append("client");
+	this->client_cpp_file.append(this->is_thrift ? ".thrift_skeleton." : ".pb_skeleton.");
+	this->client_cpp_file.append("cc");
+
+	if (this->printer.open(this->client_cpp_file) == false)
+		return false;
 
 	this->printer.print_client_file_include(idl_file_name);
 
@@ -425,6 +437,8 @@ void Generator::generate_client_cpp_file(const idl_info& cur_info, const std::st
 	}
 
 	this->printer.print_client_main_begin();
+	this->printer.print_client_main_address();
+
 	int id = 0;
 
 	for (const auto& desc : cur_info.desc_list)
@@ -462,5 +476,7 @@ void Generator::generate_client_cpp_file(const idl_info& cur_info, const std::st
 
 	this->printer.print_client_main_end();
 	this->printer.close();
+
+	return true;
 }
 

--- a/src/generator/generator.h
+++ b/src/generator/generator.h
@@ -32,7 +32,11 @@
 struct GeneratorParams
 {
 	const char *out_dir;
-	const char *out_file;
+	bool generate_skeleton;
+	std::string idl_file;
+	std::string input_dir;
+
+	GeneratorParams() : out_dir(NULL), generate_skeleton(true) { }
 };
 
 class Generator
@@ -48,17 +52,25 @@ public:
 		this->is_thrift = is_thrift;
 	}
 
-	bool generate(const std::string& idl_file, struct GeneratorParams params);
+	bool generate(struct GeneratorParams& params);
+
+protected:
+	virtual bool generate_server_cpp_file(const idl_info& cur_info,
+										  const std::string& idle_file_name);
+	virtual bool generate_client_cpp_file(const idl_info& cur_info,
+										  const std::string& idle_file_name);
+
+	std::string server_cpp_file;
+	std::string client_cpp_file;
 
 private:
-	bool generate_header(idl_info& cur_info, struct GeneratorParams params);
+	bool generate_header(idl_info& cur_info, struct GeneratorParams& params);
 	void generate_skeleton(const std::string& idl_file);
 
 	bool generate_srpc_file(const idl_info& cur_info);
 	bool generate_thrift_type_file(idl_info& cur_info);
-	void generate_server_cpp_file(const idl_info& cur_info, const std::string& idle_file_name);
-	void generate_client_cpp_file(const idl_info& cur_info, const std::string& idle_file_name);
-	void thrift_replace_include(const idl_info& cur_info, std::vector<rpc_param>& params);
+	void thrift_replace_include(const idl_info& cur_info,
+								std::vector<rpc_param>& params);
 
 	bool init_file_names(const std::string& idl_file, const char *out_dir);
 
@@ -72,8 +84,6 @@ private:
 	std::string prefix;
 	std::string srpc_file;
 	std::string thrift_type_file;
-	std::string server_cpp_file;
-	std::string client_cpp_file;
 	bool is_thrift;
 };
 

--- a/src/generator/parser.h
+++ b/src/generator/parser.h
@@ -80,7 +80,6 @@ public:
 	bool parse_include_file(const std::string& line, std::string& file_name);
 	bool check_multi_comments_begin(std::string& line);
 	bool check_multi_comments_end(std::string& line);
-	bool parse_dir_prefix(const std::string& file_name, char *dir_prefix);
 	int parse_pb_rpc_option(const std::string& line);
 	Parser(bool is_thrift) { this->is_thrift = is_thrift; }
 

--- a/src/generator/printer.h
+++ b/src/generator/printer.h
@@ -524,14 +524,16 @@ public:
 	void print_server_main_begin()
 	{
 		fprintf(this->out_file, "%s", this->server_main_begin_format.c_str());
+		if (!this->is_thrift)
+			fprintf(this->out_file, "%s", this->main_pb_version_format.c_str());
+	}
 
+	void print_server_main_address()
+	{
 		if (this->is_thrift)
 			fprintf(this->out_file, this->server_main_ip_port_format.c_str(), "Thrift");
 		else
-		{
-			fprintf(this->out_file, "%s", this->main_pb_version_format.c_str());
 			fprintf(this->out_file, this->server_main_ip_port_format.c_str(), "SRPC");
-		}
 	}
 
 	void print_server_main_method(const std::string& service)
@@ -547,6 +549,10 @@ public:
 	void print_server_main_end()
 	{
 		fprintf(this->out_file, "%s", this->server_main_end_format.c_str());
+	}
+
+	void print_server_main_return()
+	{
 		if (!this->is_thrift)
 			fprintf(this->out_file, "%s", this->main_pb_shutdown_format.c_str());
 		fprintf(this->out_file, "%s", this->main_end_return_format.c_str());
@@ -963,6 +969,10 @@ public:
 		fprintf(this->out_file, "%s", this->client_main_begin_format.c_str());
 		if (!this->is_thrift)
 			fprintf(this->out_file, "%s", this->main_pb_version_format.c_str());
+	}
+
+	void print_client_main_address()
+	{
 		fprintf(this->out_file, "%s", this->client_main_ip_port_format.c_str());
 	}
 
@@ -1044,10 +1054,11 @@ public:
 
 	Printer(bool is_thrift) { this->is_thrift = is_thrift; }
 
-private:
+protected:
 	FILE *out_file;
 	bool is_thrift;
 
+private:
 	std::string thrift_include_format = R"(#pragma once
 #include "srpc/rpc_thrift_idl.h"
 )";
@@ -1068,8 +1079,7 @@ namespace %s
 using namespace %s;
 )";
 
-	std::string srpc_file_include_format = R"(
-#include "%s.srpc.h"
+	std::string srpc_file_include_format = R"(#include "%s.srpc.h"
 #include "workflow/WFFacilities.h"
 )";
 


### PR DESCRIPTION
New usage:
```
Usage:
    ./_bin/srpc_generator [protobuf|thrift] <idl_file> <output_dir>

Available options:
    -f, --idl_file      : IDL file name. If multiple files are imported, specify the top one. Will parse recursively.
    -o, --output_dir    : Output directory.
    -i, --input_dir     : Specify the directory in which to search for imports.
    -s, --skip_skeleton : Skip generating skeleton file. (default: generate)
    -v, --version       : Show version.
    -h, --help          : Show usage.
```

Compatible with the origin usage:
```
srpc_generator protobuf test.proto ./output/
srpc_generator test.proto ./output/
srpc_generator thrift test.thrift ./output/
srpc_generator -v
```
Also support new usage:

```
srpc_generator  -f test.proto -o ./output/ 
srpc_generator  -f test.proto -o ./output/ -i /root/proto_path
srpc_generator  --idl_file=test.thrift --output_dir=./output/ 
```

Parameters can be specified first in origin style , followed by the getopt_long style:

```
srpc_generator protobuf test.proto -o ./output/ 
srpc_generator test.thrift ./output/ --input_dir=/root/proto_path
```

Support -s to skip generating client.xx_skeleton.cc and server.xx_skeleton.cc. 

Keep the error message the same as they used to shown.