### PR TITLE
Update src\generator\compiler.cc

### DIFF
--- a/src/generator/compiler.cc
+++ b/src/generator/compiler.cc
@@ -69,7 +69,7 @@ int main(int argc, const char *argv[])
 	struct GeneratorParams params;
 
 #ifndef _WIN32
-	if (parse_origin(argc, argv, params, idl_type) == 0)
+	if (parse_origin(argc, argv, params, idl_type) != 0)
 	{
 		if (parse_getopt(argc, (char * const *)argv, params, idl_type) != 0)
 			return 0;


### PR DESCRIPTION
在windows中使用时，srpc_generator不能自动生成文件。是因parse_origin函数返回0时表示参数解析成功，要使程序能继续往下执行，需要将if语句中的“==”改成“!=”。