### PR TITLE
Update RPCModule for concurrency issues.

### DIFF
--- a/src/module/rpc_filter.h
+++ b/src/module/rpc_filter.h
@@ -70,9 +70,20 @@ public:
 		this->module_type = module_type;
 	}
 
+	RPCFilter(const std::string name, enum RPCModuleType module_type)
+	{
+		size_t pos = name.find("::");
+		if (pos != std::string::npos)
+			this->filter_name = name.substr(0, pos) + "::";
+		else
+			this->filter_name = name + "::";
+		this->module_type = module_type;
+	}
+
 	virtual ~RPCFilter() { }
 
 	enum RPCModuleType get_module_type() const { return this->module_type; }
+	const std::string& get_name() const { return this->filter_name; }
 
 	virtual bool client_begin(SubTask *task, RPCModuleData& data)
 	{
@@ -91,8 +102,18 @@ public:
 		return true;
 	}
 
+	const std::string raw_var_name(const std::string& name) const
+	{
+		size_t pos = name.find("::");
+		if (pos != std::string::npos)
+			return name.substr(pos + 2);
+		else
+			return name;
+	}
+
 private:
 	enum RPCModuleType module_type;
+	std::string filter_name;
 };
 
 } // end namespace srpc

--- a/src/var/rpc_var.cc
+++ b/src/var/rpc_var.cc
@@ -458,7 +458,10 @@ RPCVar *SummaryVar::create(bool with_data)
 
 void SummaryVar::observe(double value)
 {
+	RPCVarLocal *local = RPCVarLocal::get_instance();
+	local->mutex.lock();
 	this->quantile_values.insert(value);
+	local->mutex.unlock();
 }
 
 bool SummaryVar::reduce(const void *ptr, size_t sz)
@@ -570,6 +573,20 @@ void TimedGaugeVar::increase()
 
 	for (auto& bucket : this->data_bucket)
 		bucket.increase();
+}
+
+void TimedGaugeVar::set(double val)
+{
+	this->rotate();
+
+	for (auto &bucket : this->data_bucket)
+		bucket.set(val);
+}
+
+double TimedGaugeVar::get()
+{
+	GaugeVar &bucket = this->rotate();
+	return bucket.get();
 }
 
 const void *TimedGaugeVar::get_data()

--- a/src/var/rpc_var.h
+++ b/src/var/rpc_var.h
@@ -291,6 +291,10 @@ public:
 
 	double get_sum() const { return this->sum; }
 	size_t get_count() const { return this->count; }
+	const std::vector<double> *get_bucket_boundaries() const
+	{
+		return &this->bucket_boundaries;
+	}
 	const std::vector<size_t> *get_bucket_counts() const
 	{
 		return &this->bucket_counts;
@@ -329,6 +333,18 @@ public:
 	}
 
 	void reset() override { /* no TimedSummary so no reset for Summary */}
+
+	const std::vector<struct Quantile>& get_quantiles() const
+	{
+		return this->quantiles;
+	}
+	const std::vector<double>& get_quantile_out() const
+	{
+		return this->quantile_out;
+	}
+
+	// only for clear stack variable after filled into protobuf or out_string
+	void clear_quantile_out() { this->quantile_out.clear(); }
 
 public:
 	SummaryVar(const std::string& name, const std::string& help,
@@ -402,6 +418,9 @@ public:
 				  Clock::duration duration, size_t bucket_num);
 	// for collect
 	void increase() override;
+	double get() override;
+	void set(double var) override;
+
 	// for reduce
 	const void *get_data() override;
 	RPCVar *create(bool with_data) override;

--- a/tools/templates/common/config.json
+++ b/tools/templates/common/config.json
@@ -47,6 +47,7 @@
     },
     {
       "filter": "opentelemetry",
+      "filter_name": "otel_reporter1",
       "address": "http://opentelemetry.com:4389",
       "redirect_max": 0,
       "retry_max": 1,

--- a/tools/templates/config/config_full.cc
+++ b/tools/templates/config/config_full.cc
@@ -321,6 +321,7 @@ void RPCConfig::load_metrics()
             if (it.has("address") == false)
                 continue;
 
+            std::string name = it["filter_name"];
             std::string url = it["address"];
 
             unsigned int redirect_max = OTLP_HTTP_REDIRECT_MAX;
@@ -337,7 +338,8 @@ void RPCConfig::load_metrics()
             if (it.has("report_interval_ms"))
                 report_interval = it["report_interval_ms"];
 
-            RPCMetricsOTel *filter = new RPCMetricsOTel(url,
+            RPCMetricsOTel *filter = new RPCMetricsOTel(name,
+                                                        url,
                                                         redirect_max,
                                                         retry_max,
                                                         report_threshold,


### PR DESCRIPTION
1. fix : add lock and flag when RPCFilterPolicy report();
2. feat : refactor the usage of RPCMetricsFilter::Collector;
3. feat : add filter_name and differentiate the var reported by each filter;
4. fix : add lock for SummaryVar::observe();