### PR TITLE
Fix : call RPCModule::server_task_end() after serialize_meta()

### DIFF
--- a/src/module/rpc_metrics_filter.cc
+++ b/src/module/rpc_metrics_filter.cc
@@ -726,6 +726,7 @@ void RPCMetricsOTel::Collector::collect_counter_each(const std::string& label,
 
 	if (!label.empty())
 	{
+		it = this->label_map.find(label);
 		if (it == this->label_map.end())
 		{
 			this->add_counter_label(label);

--- a/src/module/rpc_trace_module.h
+++ b/src/module/rpc_trace_module.h
@@ -262,7 +262,7 @@ bool RPCTraceModule<STASK, CTASK>::server_end(SubTask *task,
 		return true;
 	}
 
-	TraceModule::client_end_response(resp, data);
+	TraceModule::server_end_response(resp, data);
 
 	return true;
 }

--- a/src/rpc_task.inl
+++ b/src/rpc_task.inl
@@ -292,14 +292,6 @@ CommMessageOut *RPCServerTask<RPCREQ, RPCRESP>::message_out()
 	if (status_code == RPCStatusOK)
 		status_code = this->resp.compress();
 
-	// for server, this is the where series->module_data stored
-	RPCModuleData *data = this->mutable_module_data();
-
-	for (auto *module : modules_)
-		module->server_task_end(this, *data);
-
-	this->resp.set_meta_module_data(*data);
-
 	if (status_code == RPCStatusOK)
 	{
 		if (!this->resp.serialize_meta())
@@ -308,6 +300,14 @@ CommMessageOut *RPCServerTask<RPCREQ, RPCRESP>::message_out()
 
 	if (this->resp.get_status_code() == RPCStatusOK)
 		this->resp.set_status_code(status_code);
+
+	// for server, this is the where series->module_data stored
+	RPCModuleData *data = this->mutable_module_data();
+
+	for (auto *module : modules_)
+		module->server_task_end(this, *data);
+
+	this->resp.set_meta_module_data(*data);
 
 	if (status_code == RPCStatusOK)
 		return this->WFServerTask<RPCREQ, RPCRESP>::message_out();

--- a/tools/templates/config/config_full.cc
+++ b/tools/templates/config/config_full.cc
@@ -405,6 +405,7 @@ void RPCConfig::load_trace()
                 report_interval = it["report_interval_ms"];
 
             auto *filter = new RPCTraceOpenTelemetry(url,
+													 OTLP_TRACES_PATH,
                                                      redirect_max,
                                                      retry_max,
                                                      spans_per_second,


### PR DESCRIPTION
Also fix some bugs:
1. call RPCModule::server_task_end() after serialize_meta(), otherwise some necessary http fields have not been set.
2. new interface compatible : add path in RPCTraceOpenTelemetry in srpc/tools parsing config.
3. set iterator for CounterVar in collector of RPCVar.
4. RPCModule call server_end_response() in server_end().