### PR TITLE
Update bazel in build ci.yml and fix sprintf warnings.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,19 @@ jobs:
           } > podmanfile
           podman build --tag fedorarawhide -f ./podmanfile
 
+  ubuntu-bazel:
+    name: bazel
+    runs-on: ubuntu-latest
+
+     steps:
+     - uses: actions/checkout@master
+     - name: Install Bazel 5.4.0
+       run: |
+         sudo apt-get update
+         sudo apt-get install -y apt-transport-https curl gnupg
+         curl -LO "https://releases.bazel.build/5.4.0/release/bazel-5.4.0-linux-x86_64"
+         chmod +x bazel-5.4.0-linux-x86_64
+         sudo mv bazel-5.4.0-linux-x86_64 /usr/local/bin/bazel
+     - name: bazel build
+       run: bazel build ...
+

--- a/src/rpc_basic.h
+++ b/src/rpc_basic.h
@@ -177,14 +177,16 @@ static inline unsigned long long GET_CURRENT_NS()
 static inline void TRACE_ID_BIN_TO_HEX(const uint64_t trace_id[2],
 									   char hex[SRPC_TRACEID_SIZE * 2 + 1])
 {
-	sprintf(hex, "%016llx%016llx", (unsigned long long)ntohll(trace_id[0]),
-								   (unsigned long long)ntohll(trace_id[1]));
+	snprintf(hex, SRPC_TRACEID_SIZE * 2 + 1, "%016llx%016llx",
+			 (unsigned long long)ntohll(trace_id[0]),
+			 (unsigned long long)ntohll(trace_id[1]));
 }
 
 static inline void SPAN_ID_BIN_TO_HEX(const uint64_t span_id[1],
 									  char hex[SRPC_SPANID_SIZE * 2 + 1])
 {
-	sprintf(hex, "%016llx", (unsigned long long)ntohll(span_id[0]));
+	snprintf(hex, SRPC_SPANID_SIZE * 2 + 1, "%016llx",
+			 (unsigned long long)ntohll(span_id[0]));
 }
 
 static inline void TRACE_ID_HEX_TO_BIN(const char hex[SRPC_TRACEID_SIZE * 2 + 1],

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,14 +68,14 @@ else ()
 	find_package(GTest REQUIRED)
 endif ()
 
-set(CXX_STD "c++14")
+set(CMAKE_CXX_STANDARD 14)
 
 if (WIN32)
 	set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   /MP /wd4200")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /wd4200 /Zc:__cplusplus /std:c++14")
 else ()
 	set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -Wall -fPIC -pipe -std=gnu90")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -pipe -std=${CXX_STD} -fno-exceptions")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fPIC -pipe -fno-exceptions")
 endif ()
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS test_pb.proto)


### PR DESCRIPTION
- update bazel to 5.4.0 in ci.yml;
- use snprintf instead of sprintf to convert id into string;
- update test/CMakeLists.txt to use c++14;