### PR TITLE
Fix compat with protobuf 6.30.0

### DIFF
--- a/src/message/rpc_message_srpc.cc
+++ b/src/message/rpc_message_srpc.cc
@@ -106,7 +106,7 @@ private:
 
 static inline std::string GetTypeUrl(const ProtobufIDLMessage *pb_msg)
 {
-	return std::string(kTypePrefix) + "/" + pb_msg->GetDescriptor()->full_name();
+	return std::string(kTypePrefix) + "/" + std::string(pb_msg->GetDescriptor()->full_name());
 }
 
 SRPCMessage::SRPCMessage()

--- a/src/message/rpc_message_trpc.cc
+++ b/src/message/rpc_message_trpc.cc
@@ -344,7 +344,7 @@ private:
 
 static inline std::string GetTypeUrl(const ProtobufIDLMessage *pb_msg)
 {
-	return std::string(kTypePrefix) + "/" + pb_msg->GetDescriptor()->full_name();
+	return std::string(kTypePrefix) + "/" + std::string(pb_msg->GetDescriptor()->full_name());
 }
 
 TRPCMessage::TRPCMessage()


### PR DESCRIPTION
Protobuf 6.30.0 and newer return `string_view`s from `->full_name()` which cannot be concat'ed to `std::string` until C++26. Thus we convert to `std::string` first.