### PR TITLE
cmake: use C++17 with gtest 1.17 and later

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,21 @@ else ()
 endif ()
 
 set(CMAKE_CXX_STANDARD 14)
+if (GTest_VERSION VERSION_GREATER_EQUAL "1.17.0")
+	set(CMAKE_CXX_STANDARD 17)
+else ()
+	get_filename_component(GTEST_PATH ${GTEST_LIBRARY} DIRECTORY ABSOLUTE)
+	execute_process(COMMAND grep Version "${GTEST_PATH}/pkgconfig/gtest.pc"
+					RESULT_VARIABLE GTEST_VERSION_RESULT
+					OUTPUT_VARIABLE GTEST_VERSION_OUTPUT)
+	if (${GTEST_VERSION_RESULT} EQUAL "0")
+		string(REPLACE " " ";" GTEST_VERSION_STR ${GTEST_VERSION_OUTPUT})
+		list(GET GTEST_VERSION_STR 1 GTEST_VERSION)
+		if (${GTEST_VERSION} VERSION_GREATER_EQUAL "1.17.0")
+			set(CXX_STD "c++17")
+		endif ()
+	endif ()
+endif ()
 
 if (WIN32)
 	set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   /MP /wd4200")


### PR DESCRIPTION
The 1.17 branch of GoogleTest requires at least C++17; see https://github.com/google/googletest/releases/tag/v1.17.0.

Based on a patch by Terje Røsten for the srpc package in Fedora, https://src.fedoraproject.org/rpms/srpc/pull-request/1, and on the version-detection that was present to handle GoogleTest 1.13.0 and C++14 before the overall C++ standard for the project was upgraded to C++14 in b26c810e24704566c81485f5e1c988c3f73573c3.