### PR TITLE
srpc_generator : handle error when no 'service' defined in proto file.

### DIFF
--- a/src/generator/generator.cc
+++ b/src/generator/generator.cc
@@ -84,6 +84,22 @@ bool Generator::generate(struct GeneratorParams& params)
 		return false;
 	}
 
+	bool include_service_define = false;
+	for (auto& include_info : this->info.include_list)
+	{
+		if (!include_info.desc_list.empty())
+		{
+			include_service_define = true;
+			break;
+		}
+	}
+
+	if (this->info.desc_list.empty() && !include_service_define)
+	{
+		fprintf(stdout, "[Generator Error] No 'service' definition.\n");
+		return false;
+	}
+
 	if (this->generate_header(this->info, params) == false)
 	{
 		fprintf(stderr, "[Generator Error] generate failed.\n");


### PR DESCRIPTION
#### Summary
This PR is to fix the error handling when **no 'service' defined in proto file**.

We use srpc to generate the corresponding API for 'service' defined in our protobuf file or thrift file. But if we don't find any services, the error should be alerted.

#### wrong proto file example
This is wrong proto file with no 'service'. We can test it by command : **./srpc_generator protobuf data.proto ./**

```proto
syntax = "proto3";
message Content {
    bytes data = 1;
}

// service Example {
//     rpc Echo(Content) returns (Content);
// }
```

####  previous output
The output log will continue to print `./data.srpc.h `, which will not be generated because no RPC is parse.
```
<tos srpc_github_1412]$ _bin/srpc_generator protobuf ./data.proto ./          
[Generator Begin]
proto file: [data.proto]
Successfully parse service block [message] : Content
finish parsing proto file: [data.proto]
[Generator] generate srpc files: ./data.srpc.h 
[Generator Done]
[Generator] generate server files: ./server.pb_skeleton.cc, client files: ./client.pb_skeleton.cc
[Generator Done]
```

#### fixed output
This PR will print the error and stop generating files.
```
[Generator Begin]
proto file: [data.proto]
Successfully parse service block [message] : Content
finish parsing proto file: [data.proto]
[Generator Error] No 'service' definition.
[Generator Done]
```