### PR TITLE
Update srpc_generator to support thrift2.

### DIFF
--- a/src/generator/parser.cc
+++ b/src/generator/parser.cc
@@ -191,7 +191,7 @@ bool Parser::parse(const std::string& proto_file, idl_info& info)
 		if ((state & PARSER_ST_BLOCK_MASK) == PARSER_ST_INSIDE_BLOCK)
 		{
 			if (flag_append == true)
-				block.append(line);
+				block.append(line); // block.append(line + "\n");
 
 			if (this->check_block_begin(line) == true)
 				++stack_count;
@@ -758,11 +758,31 @@ bool Parser::parse_rpc_param_thrift(const std::string& file_name_prefix,
 			  continue;
 
 			auto typevar = parse_thrift_variable(filedparam[1], ' ');
-			if (typevar.size() != 2)
+
+			if (typevar.size() == 3) // for optional/required in thrift2
+			{
+				std::string qualifier = SGenUtil::strip(typevar[0]);
+				if (qualifier == "optional")
+				{
+					param.required_state = srpc::THRIFT_STRUCT_FIELD_OPTIONAL;
+					typevar.erase(typevar.begin());
+				}
+				else if (qualifier == "required")
+				{
+					param.required_state = srpc::THRIFT_STRUCT_FIELD_REQUIRED;
+					typevar.erase(typevar.begin());
+				}
+				else
+					continue; // error
+			}
+			else if (typevar.size() == 2)
+			{
+				param.required_state = srpc::THRIFT_STRUCT_FIELD_REQUIRED;
+			}
+			else
 				continue;
 
 			param.var_name = typevar[1];
-			param.required_state = srpc::THRIFT_STRUCT_FIELD_REQUIRED;
 			param.field_id = atoi(SGenUtil::strip(filedparam[0]).c_str());
 			idl_type = SGenUtil::strip(typevar[0]);
 			fill_rpc_param_type(file_name_prefix, idl_type, param, info);


### PR DESCRIPTION
### Background
Thrift2 introduces `required` and `optional` modifiers for every field. Consequently, `srpc_generator` needs to update its parser file, `parser.c`, to accommodate this change.
Related Issue: https://github.com/sogou/srpc/issues/435

Thrift2 Example: https://github.com/apache/hbase/blob/master/hbase-thrift/src/main/resources/org/apache/hadoop/hbase/thrift2/hbase.thrift

### Comparison of Differences

Thrift2 Syntax:
```
struct TColumn {
1: required binary family,
2: optional binary qualifier,
3: optional i64 timestamp
}
```

Thrift Syntax:
```
struct TColumn {
1:Text columnName,
2:TCell cell
}
```

### Notes
Please note that this commit requires every line within a code block (with the exception of the very last line) to end with a comma (`,`); otherwise, parsing will fail. However, syntax where lines do *not* end with a comma is actually also valid. To support this valid syntax, an additional modification is required:

```
191         if ((state & PARSER_ST_BLOCK_MASK) == PARSER_ST_INSIDE_BLOCK)
192         {
193             if (flag_append == true)
194                 block.append(line); // block.append(line + "\n");
```
But this modification is common for every protocol parsing. So considering the stability, this is not included in this PR.