### PR TITLE
Fix meta_len and buf_len in BRPC/TRPC and update workflow

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ rules_proto_toolchains()
 
 git_repository(
     name = "workflow",
-    commit = "fa48b351cc81f83d6435d0bd144c732476c79d4b",
+    commit = "3d5739960ac34d6164d5fec0abf268e83d72fe93",
     remote = "https://github.com/sogou/workflow.git")
 
 new_git_repository(

--- a/src/message/rpc_message_brpc.cc
+++ b/src/message/rpc_message_brpc.cc
@@ -118,6 +118,12 @@ int BRPCMessage::append(const void *buf, size_t *size, size_t size_limit)
 			buf_len = ntohl(*p); // payload_len
 			p = (uint32_t *)this->header + 2;
 			this->meta_len = ntohl(*p);
+			if (this->meta_len > buf_len)
+			{
+				errno = EBADMSG;
+				return -1;
+			}
+
 			this->message_len = buf_len - this->meta_len; // msg_len + attachment_len
 
 			if (buf_len >= size_limit)

--- a/src/message/rpc_message_trpc.cc
+++ b/src/message/rpc_message_trpc.cc
@@ -441,8 +441,15 @@ int TRPCMessage::append(const void *buf, size_t *size, size_t size_limit)
 			sp = (uint16_t *)this->header + 4;
 			this->meta_len = ntohs(*sp);
 
-			this->message_len = buf_len - TRPC_HEADER_SIZE - this->meta_len;
+			if (buf_len < TRPC_HEADER_SIZE ||
+				this->meta_len > buf_len - TRPC_HEADER_SIZE)
+			{
+				errno = EBADMSG;
+				return -1;
+			}
+
 			buf_len -= TRPC_HEADER_SIZE;
+			this->message_len = buf_len - this->meta_len;
 
 			if (buf_len >= size_limit)
 			{


### PR DESCRIPTION
# 1. FIX
## Problem

  `BRPCMessage::append()` and `TRPCMessage::append()` never validate `meta_len`
  against the payload length declared in the header. A message with a
  zero-length payload but a non-zero `meta_len` is reported as complete while
  `meta_buf` is still unallocated, and `deserialize_meta()` then dereferences
  it. Malformed input can therefore terminate the server before any dispatch
  happens. The same missing check also allows uninitialised heap to be parsed
  and `message_len` to underflow.

  SRPC and Thrift are unaffected — SRPC derives `buf_len` from
  `meta_len + message_len`, so the inconsistent case cannot arise.

  ## Fix

  Validate in `append()` rather than null-guarding `deserialize_meta()`: the
  latter would stop the crash but leave the uninitialised read and the
  underflow in place.

  - `rpc_message_brpc.cc`: reject `meta_len > buf_len` before computing
    `message_len`.
  - `rpc_message_trpc.cc`: same check after subtracting `TRPC_HEADER_SIZE`,
    plus reject `total_len < TRPC_HEADER_SIZE` so that subtraction cannot
    underflow.

  ## Testing

  Verified against the unmodified tutorial servers (tutorial-05 BRPC,
  tutorial-11 TRPC) over loopback: malformed length combinations are now
  rejected with `EBADMSG` and the server stays up, including when the input is
  delivered in split writes. Legitimate traffic is unchanged — empty messages,
  consistent meta/payload lengths, meta-plus-message, and header-only receives
  with the body still pending all parse as before. The harness itself was
  validated by reverting the patch and confirming the failure reappears.

  ## Credit

  Reported privately by Tom Watson (github.com/tfwiii).

# 2. UPDATE
update wokrflow submodule to v1.1.0